### PR TITLE
Implemented "srcset" for all of the images

### DIFF
--- a/en/codegen/after-codegen.md
+++ b/en/codegen/after-codegen.md
@@ -39,7 +39,7 @@ RouterModule.forChild(routes)
 
 So with a [RouterOutlet](https://angular.io/api/router/RouterOutlet) in place you can run the application using `npm start` in terminal and then navigate to the website in your browser, appending the name of the component to the url.
 
-![](../images/address-nav.png)
+<img src="../images/address-nav.png" srcset="../images/address-nav@2x.png 2x" />
 
 This gives a good starting point for developers.  From here it is expected that developers will change the routes to fit their application criteria.  It is also expected that developers will write some code to trigger navigation based on certain actions such as a button click.
 
@@ -51,7 +51,7 @@ Here is an example of how the process works.
 
 In Sketch, the designer places a Nebula UI Category Chart component into the artboard.
 
-![](../images/categorychart-overrides.png)
+<img src="../images/categorychart-overrides.png" srcset="../images/categorychart-overrides@2x.png 2x" />
 
 In the overrides there is a DataSource override listed and the value specified inside is what tells the generator what property it should bind the [Ignite UI for Angular](https://www.infragistics.com/products/ignite-ui-angular) control to.  In this case the chart in Sketch will turn into an `igx-category-chart` and its `dataSource` Input will bind to `olympicMedalData`.
 

--- a/en/components/avatar.md
+++ b/en/components/avatar.md
@@ -10,7 +10,7 @@ Use the Avatar Component as a graphical representation of a person through a pro
 
 ### Avatar Demo
 
-![](../images/avatar_demo.png)
+<img src="../images/avatar_demo.png" srcset="../images/avatar_demo@2x.png 2x" />
 
 ### Size
 
@@ -20,23 +20,23 @@ The Avatar comes in three different sizes:
 - Medium - Appropriate for custom menus and visualizations
 - Small - Easily embedded in a contact list and similar repetitive scenarios
 
-![](../images/avatar_sizes.png)
+<img src="../images/avatar_sizes.png" srcset="../images/avatar_sizes@2x.png 2x" />
 
 ### Type
 
 The Avatar can carry different types of content such as an **image**, a string with initials, or an icon.
 
-![](../images/avatar_content.png)
+<img src="../images/avatar_content.png" srcset="../images/avatar_content@2x.png 2x" />
 
 The avatar comes in two distinct types determined by its shape: a **round** and a square form.
 
-![](../images/avatar_type.png)
+<img src="../images/avatar_type.png" srcset="../images/avatar_type@2x.png 2x" />
 
 ### Styling
 
 The Avatar comes with styling flexibility through the various overrides controlling the background color, as well as initials and icon colors, where applicable.
 
-![](../images/avatar_styling.png)
+<img src="../images/avatar_styling.png" srcset="../images/avatar_styling@2x.png 2x" />
 
 ## Usage
 
@@ -44,7 +44,7 @@ When using an Avatar with initials or icons, pick their colors carefully to assu
 
 | Do                            | Don't                           |
 | ----------------------------- | ------------------------------- |
-| ![](../images/avatar_do1.png) | ![](../images/avatar_dont1.png) |
+| <img src="../images/avatar_do1.png" srcset="../images/avatar_do1@2x.png 2x" /> | <img src="../images/avatar_dont1.png" srcset="../images/avatar_dont1@2x.png 2x" /> |
 
 ## Code Generation
 

--- a/en/components/badge.md
+++ b/en/components/badge.md
@@ -10,25 +10,25 @@ Use the Badge Component Symbol to draw attention to another interface element or
 
 ### Badge Demo
 
-![](../images/badge_demo.png)
+<img src="../images/badge_demo.png" srcset="../images/badge_demo@2x.png 2x" />
 
 ### Shape
 
 The Badge comes in two distinct shapes: round and square.
 
-![](../images/badge_shapes.png)
+<img src="../images/badge_shapes.png" srcset="../images/badge_shapes@2x.png 2x" />
 
 ### Type
 
 The Badge can carry different types of content such as a **number** or an icon.
 
-![](../images/badge_type.png)
+<img src="../images/badge_type.png" srcset="../images/badge_type@2x.png 2x" />
 
 ### Styling
 
 The Badge comes with styling flexibility through the various overrides controlling the background and border colors, as well as the presence of a shadow that is cast on the underlying interface element.
 
-![](../images/badge_styling.png)
+<img src="../images/badge_styling.png" srcset="../images/badge_styling@2x.png 2x" />
 
 ## Usage
 
@@ -36,7 +36,7 @@ Use the Badge to "stamp" another piece of UI, such as an Avatar or a text title 
 
 | Do                           | Don't                          |
 | ---------------------------- | ------------------------------ |
-| ![](../images/badge_do1.png) | ![](../images/badge_dont1.png) |
+| <img src="../images/badge_do1.png" srcset="../images/badge_do1@2x.png 2x" /> | <img src="../images/badge_dont1.png" srcset="../images/badge_dont1@2x.png 2x" /> |
 
 ## Code Generation
 

--- a/en/components/bottom-nav.md
+++ b/en/components/bottom-nav.md
@@ -10,29 +10,29 @@ Use the Bottom Navigation Component to implement application-level navigation by
 
 ### Bottom Navigation Demo
 
-![](../images/bottom-nav_demo.png)
+<img src="../images/bottom-nav_demo.png" srcset="../images/bottom-nav_demo@2x.png 2x" />
 
 ### Items Amount
 
 The Bottom Navigation supports between two to five items. If you need to design application-level navigation with more than five items or views, consider using consider using the [Navigation Drawer](nav-drawer.md) instead.
 
-![](../images/bottom-nav_items2.png)
-![](../images/bottom-nav_items3.png)
-![](../images/bottom-nav_items4.png)
-![](../images/bottom-nav_items5.png)
+<img src="../images/bottom-nav_items2.png" srcset="../images/bottom-nav_items2@2x.png 2x" />
+<img src="../images/bottom-nav_items3.png" srcset="../images/bottom-nav_items3@2x.png 2x" />
+<img src="../images/bottom-nav_items4.png" srcset="../images/bottom-nav_items4@2x.png 2x" />
+<img src="../images/bottom-nav_items5.png" srcset="../images/bottom-nav_items5@2x.png 2x" />
 
 ### Item Style
 
 The Bottom Navigation item contains either a combination of **icon+text** or just an icon. There is always one item in active (selected) state, and the remaining items must be set to inactive.
 
-![](../images/bottom-nav_icon&text.png)
-![](../images/bottom-nav_icon.png)
+<img src="../images/bottom-nav_icon&text.png" srcset="../images/bottom-nav_icon&text@2x.png 2x" />
+<img src="../images/bottom-nav_icon.png" srcset="../images/bottom-nav_icon@2x.png 2x" />
 
 ### Styling
 
 The Bottom Navigation comes with styling flexibility through the various overrides controling the background color, as well as the item label and icon colors.
 
-![](../images/bottom-nav_styling.png)
+<img src="../images/bottom-nav_styling.png" srcset="../images/bottom-nav_styling@2x.png 2x" />
 
 ## Usage
 
@@ -40,8 +40,8 @@ The Bottom Navigation always appears on top of other content, and the shadow it 
 
 | Do                                | Don't                               |
 | --------------------------------- | ----------------------------------- |
-| ![](../images/bottom-nav_do1.png) | ![](../images/bottom-nav_dont1.png) |
-| ![](../images/bottom-nav_do2.png) | ![](../images/bottom-nav_dont2.png) |
+| <img src="../images/bottom-nav_do1.png" srcset="../images/bottom-nav_do1@2x.png 2x" /> | <img src="../images/bottom-nav_dont1.png" srcset="../images/bottom-nav_dont1@2x.png 2x" /> |
+| <img src="../images/bottom-nav_do2.png" srcset="../images/bottom-nav_do2@2x.png 2x" /> | <img src="../images/bottom-nav_dont2.png" srcset="../images/bottom-nav_dont2@2x.png 2x" /> |
 
 ## Code generation - TODO
 

--- a/en/components/button-group.md
+++ b/en/components/button-group.md
@@ -10,35 +10,35 @@ Use the Button Group Component to combine the triggers for a few related feature
 
 ### Button Group Demo
 
-![](../images/button-group_demo.png)
+<img src="../images/button-group_demo.png" srcset="../images/button-group_demo@2x.png 2x" />
 
 ### Layout
 
 The Button Group supports two layout directions: horizontal, where items are laid out left to right, and vertical, where their order is top to bottom.
 
-![](../images/button-group_horizontal.png)
-![](../images/button-group_vertical.png)
+<img src="../images/button-group_horizontal.png" srcset="../images/button-group_horizontal@2x.png 2x" />
+<img src="../images/button-group_vertical.png" srcset="../images/button-group_vertical@2x.png 2x" />
 
 ### Buttons Amount
 
 For the majority of scenarios, a Button Group needs between two to four items. If your case requires more than four items, you may want to consider designing a custom toolbar to encompass the rich set of actions you want to provide.
 
-![](../images/button-group_items2.png)
-![](../images/button-group_items3.png)
-![](../images/button-group_items4.png)
+<img src="../images/button-group_items2.png" srcset="../images/button-group_items2@2x.png 2x" />
+<img src="../images/button-group_items3.png" srcset="../images/button-group_items3@2x.png 2x" />
+<img src="../images/button-group_items4.png" srcset="../images/button-group_items4@2x.png 2x" />
 
 ### Button Type
 
 Each Button within the Button Group contains either **text** or icon and can be set in one of the following states: **default**, disabled, hover, and selected. The selected state comes in three variants that need to reflect the Button position. This is because of the addition of a border that separates the selected button from the adjacent siblings.
 
-![](../images/button-group_text.png)
-![](../images/button-group_icons.png)
+<img src="../images/button-group_text.png" srcset="../images/button-group_text@2x.png 2x" />
+<img src="../images/button-group_icons.png" srcset="../images/button-group_icons@2x.png 2x" />
 
 ### Styling
 
 The Button Group comes with styling flexibility through the various overrides controlling the background color, as well as the individual buttons' border, background, label, and icon colors.
 
-![](../images/button-group_styling.png)
+<img src="../images/button-group_styling.png" srcset="../images/button-group_styling@2x.png 2x" />
 
 ## Usage
 
@@ -46,9 +46,9 @@ Always use Buttons with consistent style and avoid combining text Buttons with i
 
 | Do                                  | Don't                                 |
 | ----------------------------------- | ------------------------------------- |
-| ![](../images/button-group_do1.png) | ![](../images/button-group_dont1.png) |
-| ![](../images/button-group_do2.png) | ![](../images/button-group_dont2.png) |
-| ![](../images/button-group_do3.png) | ![](../images/button-group_dont3.png) |
+| <img src="../images/button-group_do1.png" srcset="../images/button-group_do1@2x.png 2x" /> | <img src="../images/button-group_dont1.png" srcset="../images/button-group_dont1@2x.png 2x" /> |
+| <img src="../images/button-group_do2.png" srcset="../images/button-group_do2@2x.png 2x" /> | <img src="../images/button-group_dont2.png" srcset="../images/button-group_dont2@2x.png 2x" /> |
+| <img src="../images/button-group_do3.png" srcset="../images/button-group_do3@2x.png 2x" /> | <img src="../images/button-group_dont3.png" srcset="../images/button-group_dont3@2x.png 2x" /> |
 
 ## Code generation - TODO
 

--- a/en/components/button.md
+++ b/en/components/button.md
@@ -10,7 +10,7 @@ Use the Button Component to represent the trigger for a simple action that user 
 
 ### Button Demo
 
-![](../images/button_demo.png)
+<img src="../images/button_demo.png" srcset="../images/button_demo@2x.png 2x" />
 
 ### Type
 
@@ -21,19 +21,19 @@ Four types of Buttons are supported:
 - An Icon Button for actions that are represented only with an Icon.
 - A very prominent Floating Action Button (fab) with color fill and shadow that is used once per screen to strongly emphasize the main action.
 
-![](../images/button_types.png)
+<img src="../images/button_types.png" srcset="../images/button_types@2x.png 2x" />
 
 ### States
 
 Every type of button supports a **default**, hover, and disabled state. A button with an icon and label is also available in the default state.
 
-![](../images/button_states.png)
+<img src="../images/button_states.png" srcset="../images/button_states@2x.png 2x" />
 
 ### Styling
 
 The Buttons come with styling flexibility through the various overrides controlling the background, label, and icon colors.
 
-![](../images/button_styling.png)
+<img src="../images/button_styling.png" srcset="../images/button_styling@2x.png 2x" />
 
 ## Usage
 
@@ -41,9 +41,9 @@ When the content of a Button contains a label, it must be uppercase and with a t
 
 | Do                            | Don't                           |
 | ----------------------------- | ------------------------------- |
-| ![](../images/button_do1.png) | ![](../images/button_dont1.png) |
-| ![](../images/button_do2.png) | ![](../images/button_dont2.png) |
-| ![](../images/button_do3.png) | ![](../images/button_dont3.png) |
+| <img src="../images/button_do1.png" srcset="../images/button_do1@2x.png 2x" /> | <img src="../images/button_dont1.png" srcset="../images/button_dont1@2x.png 2x" /> |
+| <img src="../images/button_do2.png" srcset="../images/button_do2@2x.png 2x" /> | <img src="../images/button_dont2.png" srcset="../images/button_dont2@2x.png 2x" /> |
+| <img src="../images/button_do3.png" srcset="../images/button_do3@2x.png 2x" /> | <img src="../images/button_dont3.png" srcset="../images/button_dont3@2x.png 2x" /> |
 
 ## Code Generation
 

--- a/en/components/calendar.md
+++ b/en/components/calendar.md
@@ -10,43 +10,43 @@ Use the Calendar Component to visually represent a date and provide consistent m
 
 ### Calendar Demo
 
-![](../images/calendar_demo.png)
+<img src="../images/calendar_demo.png" srcset="../images/calendar_demo@2x.png 2x" />
 
 ### Layout
 
 The Calendar supports horizontal and vertical date picking modes, as well as a base calendar rendering for a simplified display and browsing. The former two are mostly used as dialogs, while the latter is preferably inline with other content.
 
-![](../images/calendar_horizontal.png)
-![](../images/calendar_vertical.png)
-![](../images/calendar_base.png)
+<img src="../images/calendar_horizontal.png" srcset="../images/calendar_horizontal@2x.png 2x" />
+<img src="../images/calendar_vertical.png" srcset="../images/calendar_vertical@2x.png 2x" />
+<img src="../images/calendar_base.png" srcset="../images/calendar_base@2x.png 2x" />
 
 ### Buttons
 
 The Calendar comes with two buttons: one for canceling the selection, which would discard any changes made to original date, and one for navigating to today's date. Upon setting both to none through the overrides, a button-less layout can be achieved.
 
-![](../images/calendar_buttons.png)
-![](../images/calendar_nobuttons.png)
+<img src="../images/calendar_buttons.png" srcset="../images/calendar_buttons@2x.png 2x" />
+<img src="../images/calendar_nobuttons.png" srcset="../images/calendar_nobuttons@2x.png 2x" />
 
 ### Content
 
 The Calendar supports picking for all three major date portions: the year, the month, and the day. Three content modes are provided, each responsible for the picking of its respective date portion.
 
-![](../images/calendar_days.png)
-![](../images/calendar_months.png)
-![](../images/calendar_years.png)
+<img src="../images/calendar_days.png" srcset="../images/calendar_days@2x.png 2x" />
+<img src="../images/calendar_months.png" srcset="../images/calendar_months@2x.png 2x" />
+<img src="../images/calendar_years.png" srcset="../images/calendar_years@2x.png 2x" />
 
 ### Week Start
 
 The start of the week is configurable by selecting between the two most common scenarios for the first day: Sunday or Monday.
 
-![](../images/calendar_sun.png)
-![](../images/calendar_mon.png)
+<img src="../images/calendar_sun.png" srcset="../images/calendar_sun@2x.png 2x" />
+<img src="../images/calendar_mon.png" srcset="../images/calendar_mon@2x.png 2x" />
 
 ### Styling
 
 The Calendar comes with styling flexibility through the various overrides controlling header background, title colors, and content month and year picker items, as well as text and background colors for the selected day, month, or year. These are applicable according to the configurations. The Cancel and Today buttons are [Flat Buttons](button.md) and can be styled accordingly.
 
-![](../images/calendar_styling.png)
+<img src="../images/calendar_styling.png" srcset="../images/calendar_styling@2x.png 2x" />
 
 ## Usage
 
@@ -54,8 +54,8 @@ Show the horizontal and vertical Calendars as a dialog that dims the rest of the
 
 | Do                              | Don't                             |
 | ------------------------------- | --------------------------------- |
-| ![](../images/calendar_do1.png) | ![](../images/calendar_dont1.png) |
-| ![](../images/calendar_do2.png) | ![](../images/calendar_dont2.png) |
+| <img src="../images/calendar_do1.png" srcset="../images/calendar_do1@2x.png 2x" /> | <img src="../images/calendar_dont1.png" srcset="../images/calendar_dont1@2x.png 2x" /> |
+| <img src="../images/calendar_do2.png" srcset="../images/calendar_do2@2x.png 2x" /> | <img src="../images/calendar_dont2.png" srcset="../images/calendar_dont2@2x.png 2x" /> |
 
 ## Code generation
 

--- a/en/components/cards-custom.md
+++ b/en/components/cards-custom.md
@@ -10,7 +10,7 @@ Use the Custom Card Component to display the same type of information that you w
 
 ### Custom Card Demo
 
-![](../images/card_custom_demo.png)
+<img src="../images/card_custom_demo.png" srcset="../images/card_custom_demo@2x.png 2x" />
 
 ### Detach from Symbol
 
@@ -30,7 +30,7 @@ In order to customize Card layouts start by dragging a `Cards/Custom` to your Ar
 
 The Custom Card has high-level styling flexibility that matches the normal Card through various overrides for text, icons, buttons, and background colors. The detaching of the symbol provides additional control over the corner rounding and elevation level.
 
-![](../images/card_custom_styling.png)
+<img src="../images/card_custom_styling.png" srcset="../images/card_custom_styling@2x.png 2x" />
 
 | Layer | Use |
 | ----------------------------- | ---------------------------------------- |
@@ -43,28 +43,28 @@ The Custom Card has high-level styling flexibility that matches the normal Card 
 
 Let's see how we can create the intricate layout for the weather forecast Card found above in five simple steps. We have dragged a Custom Card into an empty Artboard, selected the `Detach from Symbol`, and applied the available basic styling changes for the background color, corner radius, and elevation. Once that was completed, we had this for a starting point.
 
-![](../images/card_custom_layout0.png)
+<img src="../images/card_custom_layout0.png" srcset="../images/card_custom_layout0@2x.png 2x" />
 
 1.  We will reuse the Header Style and just update the strings for the Title and Subtitle Text. For now, let's ignore the Content group and move to the Actions Style, where we need to change it to Button Actions rather than the Icon Actions are default. Lastly, we will update the Left Button text and hide the Right Button by setting it to none.
-    ![](../images/card_custom_layout1.png)
+    <img src="../images/card_custom_layout1.png" srcset="../images/card_custom_layout1@2x.png 2x" />
 
 2.  Now, it is time to get back to the Content and create the layout for the weather forecast. We will start by inserting a Cards/Blocks/Header/Large Title (we can use any type of block in any Card area group), updating the title to a Size of H1, and resizing the symbol to correctly display both the title and subtitle. After updating the string values, you may delete the default paragraph, Content Style, and you should see an outcome similar to the example. As a note, deleting the default Content Style now will preserve the Content group since it now holds another element as well.
-    ![](../images/card_custom_layout2.png)
+    <img src="../images/card_custom_layout2.png" srcset="../images/card_custom_layout2@2x.png 2x" />
 
 3.  The next item to add in the Content Group is a sun illustration. You can create your own by grouping an Oval shape with a few line shapes and fixing the group width and height in the properties panel to avoid distortions. Place the sun illustration to the right of the degrees title, and your layout should look like this.
-    ![](../images/card_custom_layout3.png)
+    <img src="../images/card_custom_layout3.png" srcset="../images/card_custom_layout3@2x.png 2x" />
 
 4.  Now, we have to add a One-thumb Slider Component and a Cards/Blocks/Content/Paragraph Text for the array of labels underneath. In order to achieve our target design, we have to select the Slider and set its Label Text Style and Label Background overrides to none, which will hide the label balloon. After inserting some label values in the Paragraph Text, you should be able to achieve something similar to this.
-    ![](../images/card_custom_layout4.png)
+    <img src="../images/card_custom_layout4.png" srcset="../images/card_custom_layout4@2x.png 2x" />
 
 5.  It's time to design the detailed forecast area, and the easiest way to do that is by inserting the Cards/Blocks/Content/Paragraph Text twice: once for the weekdays and once for the degrees. In-between these two text columns, we will insert a Small Icon and duplicate it four more times to create a vertically aligned set, forming one more column. After choosing visualizations for them resonating with the forecast values, our target layout is complete.
-    ![](../images/card_custom_layout5.png)
+    <img src="../images/card_custom_layout5.png" srcset="../images/card_custom_layout5@2x.png 2x" />
 
 #### Additional Styling
 
 With this Custom Card layout, extensive additional styling is possible based on the elements that have been inserted in the card. For example, we can set a color for the text of the temperature to emphasize it and set a subtler color for the complimentary information, such as the labels underneath the slider and the weekday labels paragraph.
 
-![](../images/card_custom_layout_styled.png)
+<img src="../images/card_custom_layout_styled.png" srcset="../images/card_custom_layout_styled@2x.png 2x" />
 
 ## Additional Resources
 

--- a/en/components/cards.md
+++ b/en/components/cards.md
@@ -10,7 +10,7 @@ Use the Card Component to display information for a single object through images
 
 ### Card Demo
 
-![](../images/card_demo.png)
+<img src="../images/card_demo.png" srcset="../images/card_demo@2x.png 2x" />
 
 ### Areas
 
@@ -18,34 +18,34 @@ The Card has three distinct areas: `header` which holds a combination of title a
 
 |         |                                       |
 | ------- | ------------------------------------- |
-| header  | ![](../images/card_headerL.png)       |
-| content | ![](../images/card_content_image.png) |
-| actions | ![](../images/card_actions_icons.png) |
+| header  | <img src="../images/card_headerL.png" srcset="../images/card_headerL@2x.png 2x" />       |
+| content | <img src="../images/card_content_image.png" srcset="../images/card_content_image@2x.png 2x" /> |
+| actions | <img src="../images/card_actions_icons.png" srcset="../images/card_actions_icons@2x.png 2x" /> |
 
 ### Header
 
 The Card Header supports three distinct layouts: **Large Title** which provides a large title and a subtitle, Small Title which provides a small title and a subtitle, and Small Title Only which provides a small title and no subtitle.
 
-![](../images/card_headerL.png)
-![](../images/card_headerS.png)
-![](../images/card_header_title.png)
+<img src="../images/card_headerL.png" srcset="../images/card_headerL@2x.png 2x" />
+<img src="../images/card_headerS.png" srcset="../images/card_headerS@2x.png 2x" />
+<img src="../images/card_header_title.png" srcset="../images/card_header_title@2x.png 2x" />
 
 ### Content
 
 The Card Content supports five distinct layouts: **Array** for shortcuts like contacts, Image with or without a title, Map for showing geographical location, and Paragraph for a short description text.
 
-![](../images/card_content_shortcuts.png)
-![](../images/card_content_image.png)
-![](../images/card_content_map.png)
-![](../images/card_content_paragraph.png)
+<img src="../images/card_content_shortcuts.png" srcset="../images/card_content_shortcuts@2x.png 2x" />
+<img src="../images/card_content_image.png" srcset="../images/card_content_image@2x.png 2x" />
+<img src="../images/card_content_map.png" srcset="../images/card_content_map@2x.png 2x" />
+<img src="../images/card_content_paragraph.png" srcset="../images/card_content_paragraph@2x.png 2x" />
 
 ### Actions
 
 The Card Actions come in three distinct layouts: **Button Actions** with just a couple of Flat Buttons, Icon Actions with up to three icons, and Icon + Button Actions combining the two approaches.
 
-![](../images/card_actions_buttons.png)
-![](../images/card_actions_icons.png)
-![](../images/card_actions_mixed.png)
+<img src="../images/card_actions_buttons.png" srcset="../images/card_actions_buttons@2x.png 2x" />
+<img src="../images/card_actions_icons.png" srcset="../images/card_actions_icons@2x.png 2x" />
+<img src="../images/card_actions_mixed.png" srcset="../images/card_actions_mixed@2x.png 2x" />
 
 ### Types
 
@@ -53,16 +53,16 @@ The Card is available in one of the following layouts:
 
 |                   |                                       |
 | ----------------- | ------------------------------------- |
-| Point of Interest | ![](../images/card_poi.png)           |
-| Audio Video Card  | ![](../images/card_av.png)            |
-| Normal Pin        | ![](../images/card_normal-pin.png)    |
-| Condensed Pin     | ![](../images/card_condensed-pin.png) |
-| Shortcuts         | ![](../images/card_shortcuts.png)     |
-| Simple Card       | ![](../images/card_simple.png)        |
-| Small Card        | ![](../images/card_small.png)         |
-| Square Card       | ![](../images/card_square.png)        |
-| Text Card         | ![](../images/card_text.png)          |
-| Timeline Card     | ![](../images/card_timeline.png)      |
+| Point of Interest | <img src="../images/card_poi.png" srcset="../images/card_poi@2x.png 2x" />           |
+| Audio Video Card  | <img src="../images/card_av.png" srcset="../images/card_av@2x.png 2x" />            |
+| Normal Pin        | <img src="../images/card_normal-pin.png" srcset="../images/card_normal-pin@2x.png 2x" />    |
+| Condensed Pin     | <img src="../images/card_condensed-pin.png" srcset="../images/card_condensed-pin@2x.png 2x" /> |
+| Shortcuts         | <img src="../images/card_shortcuts.png" srcset="../images/card_shortcuts@2x.png 2x" />     |
+| Simple Card       | <img src="../images/card_simple.png" srcset="../images/card_simple@2x.png 2x" />        |
+| Small Card        | <img src="../images/card_small.png" srcset="../images/card_small@2x.png 2x" />         |
+| Square Card       | <img src="../images/card_square.png" srcset="../images/card_square@2x.png 2x" />        |
+| Text Card         | <img src="../images/card_text.png" srcset="../images/card_text@2x.png 2x" />          |
+| Timeline Card     | <img src="../images/card_timeline.png" srcset="../images/card_timeline@2x.png 2x" />      |
 
 If none of them works for your design, you may create your own [Custom Cards](cards-custom.md).
 
@@ -70,7 +70,7 @@ If none of them works for your design, you may create your own [Custom Cards](ca
 
 The Card comes with styling flexibility through the various overrides available for header, content, and actions areas such as text, icons, and button colors, as well as the possibility to choose a Card background color.
 
-![](../images/card_styling.png)
+<img src="../images/card_styling.png" srcset="../images/card_styling@2x.png 2x" />
 
 ## Usage
 
@@ -78,8 +78,8 @@ The Card usually works as an overview and entry point for more detailed informat
 
 | Do                          | Don't                         |
 | --------------------------- | ----------------------------- |
-| ![](../images/card_do1.png) | ![](../images/card_dont1.png) |
-| ![](../images/card_do2.png) | ![](../images/card_dont2.png) |
+| <img src="../images/card_do1.png" srcset="../images/card_do1@2x.png 2x" /> | <img src="../images/card_dont1.png" srcset="../images/card_dont1@2x.png 2x" /> |
+| <img src="../images/card_do2.png" srcset="../images/card_do2@2x.png 2x" /> | <img src="../images/card_dont2.png" srcset="../images/card_dont2@2x.png 2x" /> |
 
 ## Code generation
 

--- a/en/components/carousel.md
+++ b/en/components/carousel.md
@@ -10,13 +10,13 @@ Use the Carousel Component to let the user navigate through a collection of imag
 
 ### Carousel Demo
 
-![](../images/carousel_demo.png)
+<img src="../images/carousel_demo.png" srcset="../images/carousel_demo@2x.png 2x" />
 
 ### Styling
 
 The Carousel comes with styling flexibility through the various overrides controlling the navigation button background and icon colors, the indicator colors, border colors, and a slide image for the currently active slide. You should keep in mind that only one indicator may be active at a time.
 
-![](../images/carousel_styling.png)
+<img src="../images/carousel_styling.png" srcset="../images/carousel_styling@2x.png 2x" />
 
 ## Usage
 
@@ -24,8 +24,8 @@ The previous and next navigation buttons of the Carousel should always appear on
 
 | Do                              | Don't                             |
 | ------------------------------- | --------------------------------- |
-| ![](../images/carousel_do1.png) | ![](../images/carousel_dont1.png) |
-| ![](../images/carousel_do2.png) | ![](../images/carousel_dont2.png) |
+| <img src="../images/carousel_do1.png" srcset="../images/carousel_do1@2x.png 2x" /> | <img src="../images/carousel_dont1.png" srcset="../images/carousel_dont1@2x.png 2x" /> |
+| <img src="../images/carousel_do2.png" srcset="../images/carousel_do2@2x.png 2x" /> | <img src="../images/carousel_dont2.png" srcset="../images/carousel_dont2@2x.png 2x" /> |
 
 ## Code generation
 

--- a/en/components/chart-category.md
+++ b/en/components/chart-category.md
@@ -10,14 +10,14 @@ Use the Category Chart Component to wrap the density and complexity of data in a
 
 ### Category Chart Demo
 
-![](../images/category_chart_demo.png)
+<img src="../images/category_chart_demo.png" srcset="../images/category_chart_demo@2x.png 2x" />
 
 ### Tooltip
 
 The Category Chart comes with an override for the tooltip visibility: **Tooltip Off** hides it and Tooltip On shows it on top of the series.
 
-![](../images/chart_category_tooltip-off.png)
-![](../images/chart_category_tooltip-on.png)
+<img src="../images/chart_category_tooltip-off.png" srcset="../images/chart_category_tooltip-off@2x.png 2x" />
+<img src="../images/chart_category_tooltip-on.png" srcset="../images/chart_category_tooltip-on@2x.png 2x" />
 
 ### Types
 
@@ -25,15 +25,15 @@ The Category Chart comes with flexibility for selecting the Chart type through v
 
 |             |                                               |
 | ----------- | --------------------------------------------- |
-| Area        | ![](../images/chart_category_area.png)        |
-| Column      | ![](../images/chart_category_column.png)      |
-| Line        | ![](../images/chart_category_line.png)        |
-| Point       | ![](../images/chart_category_point.png)       |
-| Spline      | ![](../images/chart_category_spline.png)      |
-| Spline Area | ![](../images/chart_category_spline-area.png) |
-| Step Area   | ![](../images/chart_category_step-area.png)   |
-| Step Line   | ![](../images/chart_category_step-line.png)   |
-| Waterfall   | ![](../images/chart_category_waterfall.png)   |
+| Area        | <img src="../images/chart_category_area.png" srcset="../images/chart_category_area@2x.png 2x" />        |
+| Column      | <img src="../images/chart_category_column.png" srcset="../images/chart_category_column@2x.png 2x" />      |
+| Line        | <img src="../images/chart_category_line.png" srcset="../images/chart_category_line@2x.png 2x" />        |
+| Point       | <img src="../images/chart_category_point.png" srcset="../images/chart_category_point@2x.png 2x" />       |
+| Spline      | <img src="../images/chart_category_spline.png" srcset="../images/chart_category_spline@2x.png 2x" />      |
+| Spline Area | <img src="../images/chart_category_spline-area.png" srcset="../images/chart_category_spline-area@2x.png 2x" /> |
+| Step Area   | <img src="../images/chart_category_step-area.png" srcset="../images/chart_category_step-area@2x.png 2x" />   |
+| Step Line   | <img src="../images/chart_category_step-line.png" srcset="../images/chart_category_step-line@2x.png 2x" />   |
+| Waterfall   | <img src="../images/chart_category_waterfall.png" srcset="../images/chart_category_waterfall@2x.png 2x" />   |
 
 ## Usage
 
@@ -41,7 +41,7 @@ Even though you might need to combine different types of series in the same char
 
 | Do                                    | Don't                                   |
 | ------------------------------------- | --------------------------------------- |
-| ![](../images/chart_category_do1.png) | ![](../images/chart_category_dont1.png) |
+| <img src="../images/chart_category_do1.png" srcset="../images/chart_category_do1@2x.png 2x" /> | <img src="../images/chart_category_dont1.png" srcset="../images/chart_category_dont1@2x.png 2x" /> |
 
 ## Code Generation
 

--- a/en/components/checkbox.md
+++ b/en/components/checkbox.md
@@ -10,27 +10,27 @@ Use the Checkbox Component to allow the user make a selection, which most often 
 
 ### Checkbox Demo
 
-![](../images/checkbox_demo.png)
+<img src="../images/checkbox_demo.png" srcset="../images/checkbox_demo@2x.png 2x" />
 
 ### Theme
 
 The Checkbox can be used styled in **dark** and light variants to assure good readability and contrast for both lighter and darker backgrounds.
 
-![](../images/checkbox_dark.png)
-![](../images/checkbox_light.png)
+<img src="../images/checkbox_dark.png" srcset="../images/checkbox_dark@2x.png 2x" />
+<img src="../images/checkbox_light.png" srcset="../images/checkbox_light@2x.png 2x" />
 
 ### State
 
 The Checkbox provides **on**, off, and indeterminate selection states with additional variants for a disabled interaction state.
 
-![](../images/checkbox_states.png)
-![](../images/checkbox_selection.png)
+<img src="../images/checkbox_states.png" srcset="../images/checkbox_states@2x.png 2x" />
+<img src="../images/checkbox_selection.png" srcset="../images/checkbox_selection@2x.png 2x" />
 
 ### Styling
 
 The Checkbox comes with styling flexibility through the various overrides controlling its check and fill colors, as well as the label text color.
 
-![](../images/calendar_styling.png)
+<img src="../images/calendar_styling.png" srcset="../images/calendar_styling@2x.png 2x" />
 
 ## Usage
 
@@ -38,7 +38,7 @@ When many Checkboxes are necessary, you'll want to arrange them in a column grou
 
 | Do                              | Don't                             |
 | ------------------------------- | --------------------------------- |
-| ![](../images/checkbox_do1.png) | ![](../images/checkbox_dont1.png) |
+| <img src="../images/checkbox_do1.png" srcset="../images/checkbox_do1@2x.png 2x" /> | <img src="../images/checkbox_dont1.png" srcset="../images/checkbox_dont1@2x.png 2x" /> |
 
 ## Code Generation
 

--- a/en/components/dialog.md
+++ b/en/components/dialog.md
@@ -10,21 +10,21 @@ Use the Dialog Component to show a message or alert to the user, allowing him to
 
 ### Dialog Demo
 
-![](../images/dialog_demo.png)
+<img src="../images/dialog_demo.png" srcset="../images/dialog_demo@2x.png 2x" />
 
 ### Types
 
 The Dialog can be used to show an alert with only a confirming button, a message with cancellation and confirmation, or as a container for action that needs immediate attention, such as a user logging into his account.
 
-![](../images/dialog_alert.png)
-![](../images/dialog_standard.png)
-![](../images/dialog_custom.png)
+<img src="../images/dialog_alert.png" srcset="../images/dialog_alert@2x.png 2x" />
+<img src="../images/dialog_standard.png" srcset="../images/dialog_standard@2x.png 2x" />
+<img src="../images/dialog_custom.png" srcset="../images/dialog_custom@2x.png 2x" />
 
 ### Styling
 
 The Dialog comes with styling flexibility through the various overrides for its title and message, as well as the buttons at the bottom that individually styled as flat or raised with all the styling options that these two [Button](button.md) types provide.
 
-![](../images/dialog_styling.png)
+<img src="../images/dialog_styling.png" srcset="../images/dialog_styling@2x.png 2x" />
 
 ## Usage
 
@@ -32,7 +32,7 @@ When designing a custom content Dialog, avoid placing buttons in the content sec
 
 | Do                            | Don't                           |
 | ----------------------------- | ------------------------------- |
-| ![](../images/dialog_do1.png) | ![](../images/dialog_dont1.png) |
+| <img src="../images/dialog_do1.png" srcset="../images/dialog_do1@2x.png 2x" /> | <img src="../images/dialog_dont1.png" srcset="../images/dialog_dont1@2x.png 2x" /> |
 
 ## Code Generation
 

--- a/en/components/grid-column-pinning.md
+++ b/en/components/grid-column-pinning.md
@@ -10,7 +10,7 @@ Use the Grid Column Pinning Component to fix the first few columns of a scrollab
 
 ### Grid Column Pinning Demo
 
-![](../images/grid_column_pinning_demo.png)
+<img src="../images/grid_column_pinning_demo.png" srcset="../images/grid_column_pinning_demo@2x.png 2x" />
 
 ### Cell Right Border
 

--- a/en/components/grid-filter.md
+++ b/en/components/grid-filter.md
@@ -10,21 +10,21 @@ Use the Grid Filter Component to let the user specify filtering criteria on a Gr
 
 ### Grid Filter Demo
 
-![](../images/grid_filter_demo.png)
+<img src="../images/grid_filter_demo.png" srcset="../images/grid_filter_demo@2x.png 2x" />
 
 ### Filter State
 
 The Grid Filter State found in the Header Cell provides choice between the three states of interaction with filtering: **inactive** state indicating the possibility to apply filtering on the column, active state for when the a dialog is visible to allow defining of the filtering criteria, and filtered state to indicate that a filter has been applied once the dialog is no longer visible.
 
-![](../images/grid_filter_state_inactive.png)
-![](../images/grid_filter_state_active.png)
-![](../images/grid_filter_state_filtered.png)
+<img src="../images/grid_filter_state_inactive.png" srcset="../images/grid_filter_state_inactive@2x.png 2x" />
+<img src="../images/grid_filter_state_active.png" srcset="../images/grid_filter_state_active@2x.png 2x" />
+<img src="../images/grid_filter_state_filtered.png" srcset="../images/grid_filter_state_filtered@2x.png 2x" />
 
 ### Styling
 
 The Grid Filter State found in the Header Cell comes with styling flexibility through various overrides for the icon and active background colors. The Grid Filter dialog comes with styling flexibility through the various overrides for the dialog background color, as well as the available styling for the [Inputs](input.md) and [Flat Buttons](button.md) used.
 
-![](../images/grid_filter_styling.png)
+<img src="../images/grid_filter_styling.png" srcset="../images/grid_filter_styling@2x.png 2x" />
 
 ## Additional Resources
 

--- a/en/components/grid-paging.md
+++ b/en/components/grid-paging.md
@@ -10,13 +10,13 @@ Use the Grid Paging Component to inform the user about his current position and 
 
 ### Grid Paging Demo
 
-![](../images/grid_paging_demo.png)
+<img src="../images/grid_paging_demo.png" srcset="../images/grid_paging_demo@2x.png 2x" />
 
 ### Styling
 
 The Grid Paging comes with styling flexibility through the various overrides controlling its label and background colors, as well as the available styling for the Icon Buttons used for navigation.
 
-![](../images/grid_paging_styling.png)
+<img src="../images/grid_paging_styling.png" srcset="../images/grid_paging_styling@2x.png 2x" />
 
 ## Additional Resources
 

--- a/en/components/grid-summaries.md
+++ b/en/components/grid-summaries.md
@@ -10,29 +10,29 @@ Use the Grid Summaries Component to show aggregated values calculated over all t
 
 ### Grid Summaries Demo
 
-![](../images/grid_summaries_demo.png)
+<img src="../images/grid_summaries_demo.png" srcset="../images/grid_summaries_demo@2x.png 2x" />
 
 ### State
 
 The Grid Summary Cell supports the following interactive states: **active** which shows a summary Label and Number, inactive which shows a grayed out Label and hides the Number, and unavailable
 which is used to fill the gaps when one column has less Summaries than another.
 
-![](../images/grid_cell_summary_active.png)
-![](../images/grid_cell_summary_inactive.png)
-![](../images/grid_cell_summary_unavailable.png)
+<img src="../images/grid_cell_summary_active.png" srcset="../images/grid_cell_summary_active@2x.png 2x" />
+<img src="../images/grid_cell_summary_inactive.png" srcset="../images/grid_cell_summary_inactive@2x.png 2x" />
+<img src="../images/grid_cell_summary_unavailable.png" srcset="../images/grid_cell_summary_unavailable@2x.png 2x" />
 
 ### Type
 
 The Grid Summary Cell provides presets for the two generic types of data aggregates that it needs to accommodate: **Number** for numeric values and Text for strings.
 
-![](../images/grid_cell_summary_number.png)
-![](../images/grid_cell_summary_text.png)
+<img src="../images/grid_cell_summary_number.png" srcset="../images/grid_cell_summary_number@2x.png 2x" />
+<img src="../images/grid_cell_summary_text.png" srcset="../images/grid_cell_summary_text@2x.png 2x" />
 
 ### Styling
 
 The Grid Summary Cell comes with basic styling flexibility through the various overrides controlling its label and number text colors, as well as the cell background color.
 
-![](../images/grid_summaries_styling.png)
+<img src="../images/grid_summaries_styling.png" srcset="../images/grid_summaries_styling@2x.png 2x" />
 
 ## Additional Resources
 

--- a/en/components/grid.md
+++ b/en/components/grid.md
@@ -10,7 +10,7 @@ Use the Grid Component to let the user browse and interact with vast amount of c
 
 ### Grid Demo
 
-![](../images/grid_demo.png)
+<img src="../images/grid_demo.png" srcset="../images/grid_demo@2x.png 2x" />
 
 ### Detach from Symbol
 
@@ -29,45 +29,45 @@ After detaching, you may add the number of headers you need to show all the dime
 
 The Grid provides three types of cells serving different data visualization purposes. The Header Cell is only one per column and appears at the top of the grid to display the textual description of the data in that particular column. The Body Cell is used to build the table displaying data records and may vary. The Summary Cell is used to create a section at the bottom of the Grid where column [Summaries](grid-summaries.md) are displayed for each dimension such as count, minimum, and maximum value.
 
-![](../images/grid_cell_header.png)
-![](../images/grid_cell_body.png)
-![](../images/grid_cell_summary.png)
+<img src="../images/grid_cell_header.png" srcset="../images/grid_cell_header@2x.png 2x" />
+<img src="../images/grid_cell_body.png" srcset="../images/grid_cell_body@2x.png 2x" />
+<img src="../images/grid_cell_summary.png" srcset="../images/grid_cell_summary@2x.png 2x" />
 
 ### Items (Header Cell)
 
 The Grid Header Cell supports the following layout combinations through the Items override: **No Icon** which shows only a header text, Icon which shows header text and filtering icon, and Icons which shows header text, filtering icon, and sorting icon.
 
-![](../images/grid_cell_header_no-icon.png)
-![](../images/grid_cell_header_icon.png)
-![](../images/grid_cell_header_icons.png)
+<img src="../images/grid_cell_header_no-icon.png" srcset="../images/grid_cell_header_no-icon@2x.png 2x" />
+<img src="../images/grid_cell_header_icon.png" srcset="../images/grid_cell_header_icon@2x.png 2x" />
+<img src="../images/grid_cell_header_icons.png" srcset="../images/grid_cell_header_icons@2x.png 2x" />
 
 ### State (Body Cell)
 
 The Grid Body Cell supports the following interactive states: **Rest** for the normal state, CellSelected for the selected cell in cell selection mode, and RowSelected for the remaining cells on the row, where the selected cell belongs.
 
-![](../images/grid_cell_body_rest.png)
-![](../images/grid_cell_body_cell-selected.png)
-![](../images/grid_cell_body_row-selected.png)
+<img src="../images/grid_cell_body_rest.png" srcset="../images/grid_cell_body_rest@2x.png 2x" />
+<img src="../images/grid_cell_body_cell-selected.png" srcset="../images/grid_cell_body_cell-selected@2x.png 2x" />
+<img src="../images/grid_cell_body_row-selected.png" srcset="../images/grid_cell_body_row-selected@2x.png 2x" />
 
 ### Cell Type
 
 The Grid Header Cell provides presets for the three generic types of data that it needs to accommodate: **Number** for numeric values, Text for strings, and Checbox that is usually used as a template for the first column in order to allow selection of multiple rows.
 
-![](../images/grid_cell_header_number.png)
-![](../images/grid_cell_header_text.png)
-![](../images/grid_cell_header_checkbox.png)
+<img src="../images/grid_cell_header_number.png" srcset="../images/grid_cell_header_number@2x.png 2x" />
+<img src="../images/grid_cell_header_text.png" srcset="../images/grid_cell_header_text@2x.png 2x" />
+<img src="../images/grid_cell_header_checkbox.png" srcset="../images/grid_cell_header_checkbox@2x.png 2x" />
 
 The Grid Body Cell provides presets for the same generic types of data like the Header Cell.
 
-![](../images/grid_cell_body_number.png)
-![](../images/grid_cell_body_text.png)
-![](../images/grid_cell_body_checkbox.png)
+<img src="../images/grid_cell_body_number.png" srcset="../images/grid_cell_body_number@2x.png 2x" />
+<img src="../images/grid_cell_body_text.png" srcset="../images/grid_cell_body_text@2x.png 2x" />
+<img src="../images/grid_cell_body_checkbox.png" srcset="../images/grid_cell_body_checkbox@2x.png 2x" />
 
 ### Styling
 
 The Grid comes with styling flexibility achievable through styling the individual cell text, icons, and background colors in the various states available, as well as the hiding of horizontal and vertical borders.
 
-![](../images/grid_styling.png)
+<img src="../images/grid_styling.png" srcset="../images/grid_styling@2x.png 2x" />
 
 ## Usage
 
@@ -75,7 +75,7 @@ The most important thing about the Grid is the alignment of the data inside its 
 
 | Do                          | Don't                         |
 | --------------------------- | ----------------------------- |
-| ![](../images/grid_do1.png) | ![](../images/grid_dont1.png) |
+| <img src="../images/grid_do1.png" srcset="../images/grid_do1@2x.png 2x" /> | <img src="../images/grid_dont1.png" srcset="../images/grid_dont1@2x.png 2x" /> |
 
 ## Code generation
 

--- a/en/components/hyperlink.md
+++ b/en/components/hyperlink.md
@@ -10,19 +10,19 @@ Use the Hyperlink Component to allow the user access additional information rela
 
 ### Hyperlink Demo
 
-![](../images/hyperlink_demo.png)
+<img src="../images/hyperlink_demo.png" srcset="../images/hyperlink_demo@2x.png 2x" />
 
 ### Size
 
 The Hyperlink comes in two different sizes matching the available sizes for paragraph text: a 16pt Body 1 and a 14pt Body 2.
 
-![](../images/hyperlink_sizes.png)
+<img src="../images/hyperlink_sizes.png" srcset="../images/hyperlink_sizes@2x.png 2x" />
 
 ### Styling
 
 The Hyperlink can be styled through the Styling library by changing its default blue color to another one.
 
-![](../images/calendar_styling.png)
+<img src="../images/calendar_styling.png" srcset="../images/calendar_styling@2x.png 2x" />
 
 ## Usage
 
@@ -30,7 +30,7 @@ Always choose a Hyperlink text color that makes it stand out in a paragraph. Avo
 
 | Do                               | Don't                              |
 | -------------------------------- | ---------------------------------- |
-| ![](../images/hyperlink_do1.png) | ![](../images/hyperlink_dont1.png) |
+| <img src="../images/hyperlink_do1.png" srcset="../images/hyperlink_do1@2x.png 2x" /> | <img src="../images/hyperlink_dont1.png" srcset="../images/hyperlink_dont1@2x.png 2x" /> |
 
 ## Code Generation
 

--- a/en/components/icon.md
+++ b/en/components/icon.md
@@ -10,7 +10,7 @@ Use the Icon Component to provide subtle graphical information to the user that,
 
 ### Icon Demo
 
-![](../images/icon_demo.png)
+<img src="../images/icon_demo.png" srcset="../images/icon_demo@2x.png 2x" />
 
 ### Size
 
@@ -21,13 +21,13 @@ The Icon comes in four different sizes:
 - Medium
 - Small
 
-![](../images/icon_sizes.png)
+<img src="../images/icon_sizes.png" srcset="../images/icon_sizes@2x.png 2x" />
 
 ### Styling
 
 The Icon comes with styling flexibility through the overrides for selectable graphic and the color used to fill it.
 
-![](../images/icon_styling.png)
+<img src="../images/icon_styling.png" srcset="../images/icon_styling@2x.png 2x" />
 
 ## Usage
 
@@ -35,7 +35,7 @@ Carefully pick the Icon color to assure good contrast with the background and de
 
 | Do                          | Don't                         |
 | --------------------------- | ----------------------------- |
-| ![](../images/icon_do1.png) | ![](../images/icon_dont1.png) |
+| <img src="../images/icon_do1.png" srcset="../images/icon_do1@2x.png 2x" /> | <img src="../images/icon_dont1.png" srcset="../images/icon_dont1@2x.png 2x" /> |
 
 ## Code Generation
 

--- a/en/components/input.md
+++ b/en/components/input.md
@@ -10,54 +10,54 @@ Use the Input Component to collect user data such as strings and numbers fitting
 
 ### Input Demo
 
-![](../images/input_demo.png)
+<img src="../images/input_demo.png" srcset="../images/input_demo@2x.png 2x" />
 
 ### Types
 
 The Input comes with or without a helper text and provides choice between four distinct types, e.g. line style for a more airy style or border style for a more structured perception on solid color backgrounds. The boxed style is most appropriate when the Input is placed on top of an vivid image to improve readability of its content.
 
-![](../images/input_no-helper.png)
-![](../images/input_helper.png)
+<img src="../images/input_no-helper.png" srcset="../images/input_no-helper@2x.png 2x" />
+<img src="../images/input_helper.png" srcset="../images/input_helper@2x.png 2x" />
 
-![](../images/input_line.png)
+<img src="../images/input_line.png" srcset="../images/input_line@2x.png 2x" />
 `line`
-![](../images/input_box.png)
+<img src="../images/input_box.png" srcset="../images/input_box@2x.png 2x" />
 `box`
-![](../images/input_border.png)
+<img src="../images/input_border.png" srcset="../images/input_border@2x.png 2x" />
 `border`
-![](../images/input_search.png)
+<img src="../images/input_search.png" srcset="../images/input_search@2x.png 2x" />
 `search`
 
 ### Variants
 
 The Input can be used styled in **dark** and light variants to assure good readability and contrast for both lighter and darker backgrounds.
 
-![](../images/input_dark.png)
-![](../images/input_light.png)
+<img src="../images/input_dark.png" srcset="../images/input_dark@2x.png 2x" />
+<img src="../images/input_light.png" srcset="../images/input_light@2x.png 2x" />
 
 ### State
 
 When the user interacts with the Input, it goes through various states: **idle** with a placeholder in the place of the content, focused while the user is typing in it, filled once the user has finished adding content and moved on, and disabled when the input does not support any interaction. These flexibility enhancements afford a more dynamic interaction design that can seamlessly flow into high-fidelity prototyping.
 
-![](../images/input_focused.png)
+<img src="../images/input_focused.png" srcset="../images/input_focused@2x.png 2x" />
 `focused`
-![](../images/input_filled.png)
+<img src="../images/input_filled.png" srcset="../images/input_filled@2x.png 2x" />
 `filled`
-![](../images/input_disabled.png)
+<img src="../images/input_disabled.png" srcset="../images/input_disabled@2x.png 2x" />
 `disabled`
 
 Every experienced designer uses constraints wisely to limit the user input and avoid invalid states, hence the availability of validation styles. Through the available validation styles, the Input is equipped for sophisticated designs that display success, warning, and error visuals.
 
-![](../images/input_success.png)
-![](../images/input_warning.png)
-![](../images/input_error.png)
+<img src="../images/input_success.png" srcset="../images/input_success@2x.png 2x" />
+<img src="../images/input_warning.png" srcset="../images/input_warning@2x.png 2x" />
+<img src="../images/input_error.png" srcset="../images/input_error@2x.png 2x" />
 
 ### Layout
 
 The Input has rich support for prefix and suffix through text string or icon that can, in certain cases, reduce the input effort for the user: e.g. an @email.com suffix means both less keystrokes and more clarity of expected content, while a clock or calendar prefix may indicate that the Input is suitable to provide time or date as content.
 
-![](../images/input_prefix.png)
-![](../images/input_suffix.png)
+<img src="../images/input_prefix.png" srcset="../images/input_prefix@2x.png 2x" />
+<img src="../images/input_suffix.png" srcset="../images/input_suffix@2x.png 2x" />
 
 > [!Note]
 > ↳ Layout
@@ -72,14 +72,14 @@ The Input has rich support for prefix and suffix through text string or icon tha
 
 These two are special types of Input customized for the purposes of date and time selection. They have a consistent structure with the other Inputs, but the layout, which is fixed in a certain way for each state. The icons that appear at the prefix location are set to the Material Icons `calendar-today` and `access-time` and can not be changed via the overrides panel.
 
-![](../images/input_calendar.png)
-![](../images/input_time-picker.png)
+<img src="../images/input_calendar.png" srcset="../images/input_calendar@2x.png 2x" />
+<img src="../images/input_time-picker.png" srcset="../images/input_time-picker@2x.png 2x" />
 
 ### Styling
 
 The Input comes with styling achievable through changing the primary, success, warning, and error colors of your theme in the Styling library.
 
-![](../images/input_styling.png)
+<img src="../images/input_styling.png" srcset="../images/input_styling@2x.png 2x" />
 
 ## Usage
 
@@ -87,8 +87,8 @@ Use the box type of Input when placing forms on top of an image to improve reada
 
 | Do                           | Don't                          |
 | ---------------------------- | ------------------------------ |
-| ![](../images/input_do1.png) | ![](../images/input_dont1.png) |
-| ![](../images/input_do2.png) | ![](../images/input_dont2.png) |
+| <img src="../images/input_do1.png" srcset="../images/input_do1@2x.png 2x" /> | <img src="../images/input_dont1.png" srcset="../images/input_dont1@2x.png 2x" /> |
+| <img src="../images/input_do2.png" srcset="../images/input_do2@2x.png 2x" /> | <img src="../images/input_dont2.png" srcset="../images/input_dont2@2x.png 2x" /> |
 
 ## Code generation
 

--- a/en/components/list-custom.md
+++ b/en/components/list-custom.md
@@ -10,14 +10,14 @@ Use the Custom List Item Component to display the same type of information that 
 
 ### Custom List Item Demo
 
-![](../images/list_item_custom_demo.png)
+<img src="../images/list_item_custom_demo.png" srcset="../images/list_item_custom_demo@2x.png 2x" />
 
 ### State
 
 The Custom List Item supports the following interactive states: inactive for the normal state and active for the selected state.
 
-![](../images/list_item_custom_inactive.png)
-![](../images/list_item_custom_active.png)
+<img src="../images/list_item_custom_inactive.png" srcset="../images/list_item_custom_inactive@2x.png 2x" />
+<img src="../images/list_item_custom_active.png" srcset="../images/list_item_custom_active@2x.png 2x" />
 
 ### Detach from Symbol
 
@@ -34,28 +34,28 @@ In order to customize List Item layouts, start by dragging a `List/Custom/Item` 
 
 The Custom List Item has high-level styling flexibility similar to the normal List Item with a few overrides for the Secondary Actions and control over their text, icons, and buttons colors. Just like every List Item, it is possible to specify the Item background color through the overrides, as well.
 
-![](../images/list_item_custom_styling.png)
+<img src="../images/list_item_custom_styling.png" srcset="../images/list_item_custom_styling@2x.png 2x" />
 
 #### Layout
 
 So, let's see how we can create the intricate layout for the product List Item above in three simple steps. Once we have dragged in a Custom List Item in an empty Artboard, selected the `Detach from Symbol` and applied the basic styling available by changing the background color inside the state, we should have something like this for a starting point.
 
-![](../images/list_item_custom_layout0.png)
+<img src="../images/list_item_custom_layout0.png" srcset="../images/list_item_custom_layout0@2x.png 2x" />
 
 1.  We will reuse the Header from the Primary Action Group but resize it to fit in the right half only and update the strings for the Title and Subtitle Text. In the Secondary Action Group, we will add a Raised Button position to it near the bottom right corner, updating its text and resizing accordingly to fit the new value. Lastly, let's remove the default Secondary Action, as we will not be needing Icons for our target custom layout.
-    ![](../images/list_item_custom_layout1.png)
+    <img src="../images/list_item_custom_layout1.png" srcset="../images/list_item_custom_layout1@2x.png 2x" />
 
 2.  Next, we will insert a List/Custom/Blocks/Image Content in the Primary Action Group and add a Badge on top of it within the same group. Now, we have to size the image according to the Item size and select content for it. After modifying the Badge, as well by updating its Value Text and hiding its Border and Elevation, we should have something similar to this.
-    ![](../images/list_item_custom_layout2.png)
+    <img src="../images/list_item_custom_layout2.png" srcset="../images/list_item_custom_layout2@2x.png 2x" />
 
 3.  In the last step, we will add a couple of Text/Title elements to the Primary Action Group: a larger H3 to display the price of the product and a smaller H6 to its right for complimentary text. After positioning them in the empty space between the Header and the Raised Button, we can make a final alignment adjustment to the Raised Button with which our target layout is complete.
-    ![](../images/list_item_custom_layout3.png)
+    <img src="../images/list_item_custom_layout3.png" srcset="../images/list_item_custom_layout3@2x.png 2x" />
 
 #### Additional Styling
 
 With this List Item layout, a lot of additional styling is possible based on the elements that have been inserted in it. For example, we can set a color for the text of the pricing to emphasize it and change the Badge background and Raised Button background colors.
 
-![](../images/list_item_custom_layout_styled.png)
+<img src="../images/list_item_custom_layout_styled.png" srcset="../images/list_item_custom_layout_styled@2x.png 2x" />
 
 ## Additional Resources
 

--- a/en/components/list.md
+++ b/en/components/list.md
@@ -10,7 +10,7 @@ Use the List Component to let the user browse and interact with a continuous, ve
 
 ### List Demo
 
-![](../images/list_demo.png)
+<img src="../images/list_demo.png" srcset="../images/list_demo@2x.png 2x" />
 
 ### Detach from Symbol
 
@@ -31,23 +31,23 @@ After detaching, you may insert additional headers or items either from the Sket
 
 The List Item comes in three preset Types: Header for defining the headings of groups, One-line for shorter items with only one line of text, and Two-line for taller items supporting primary and secondary text.
 
-![](../images/list_item_header.png)
-![](../images/list_item_one-line.png)
-![](../images/list_item_two-line.png)
+<img src="../images/list_item_header.png" srcset="../images/list_item_header@2x.png 2x" />
+<img src="../images/list_item_one-line.png" srcset="../images/list_item_one-line@2x.png 2x" />
+<img src="../images/list_item_two-line.png" srcset="../images/list_item_two-line@2x.png 2x" />
 
 ### List Item State
 
 The One-line and Two-line List Items support the following interactive states: **inactive** for the normal state and active for the selected state. The Header List Item is not selectable so it provides no support for such States.
 
-![](../images/list_item_inactive.png)
-![](../images/list_item_active.png)
+<img src="../images/list_item_inactive.png" srcset="../images/list_item_inactive@2x.png 2x" />
+<img src="../images/list_item_active.png" srcset="../images/list_item_active@2x.png 2x" />
 
 ### List Item Areas
 
 The List Item has two distinct areas: Primary Action with non-interactive content is laid out such as Avatar and text, and Secondary Action with quick actions related to the List Item. Any combination of a Primary and Secondary action forms a valid list item template that should be used consistently across the items of the List.
 
-![](../images/list_item_primary.png)
-![](../images/list_item_secondary.png)
+<img src="../images/list_item_primary.png" srcset="../images/list_item_primary@2x.png 2x" />
+<img src="../images/list_item_secondary.png" srcset="../images/list_item_secondary@2x.png 2x" />
 
 ### List Item Primary Action
 
@@ -55,16 +55,16 @@ There are numerous interchangable List Item Primary Actions that are listed belo
 
 |                              |                                        |                                                                                                                                            |
 | ---------------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| Avatar + Description + Label | ![](../images/list_item_primary.png)   |                                                                                                                                            |
-| Avatar + Label               | ![](../images/list_item_primary2.png)  |                                                                                                                                            |
-| Avatar + Label + Description | ![](../images/list_item_primary3.png)  |                                                                                                                                            |
-| Description + Label          | ![](../images/list_item_primary4.png)  |                                                                                                                                            |
-| Icon + Description + Label   | ![](../images/list_item_primary5.png)  |                                                                                                                                            |
-| Icon + Label                 | ![](../images/list_item_primary6.png)  |                                                                                                                                            |
-| Icon + Label + Description   | ![](../images/list_item_primary7.png)  |                                                                                                                                            |
-| Label                        | ![](../images/list_item_primary8.png)  |                                                                                                                                            |
-| Label + Description          | ![](../images/list_item_primary9.png)  |                                                                                                                                            |
-| Label + Progress             | ![](../images/list_item_primary10.png) | Progress in a Primary Action can not have underlying text, therefore, the Text Style is set to None and this setting should not be changed |
+| Avatar + Description + Label | <img src="../images/list_item_primary.png" srcset="../images/list_item_primary@2x.png 2x" />   |                                                                                                                                            |
+| Avatar + Label               | <img src="../images/list_item_primary2.png" srcset="../images/list_item_primary2@2x.png 2x" />  |                                                                                                                                            |
+| Avatar + Label + Description | <img src="../images/list_item_primary3.png" srcset="../images/list_item_primary3@2x.png 2x" />  |                                                                                                                                            |
+| Description + Label          | <img src="../images/list_item_primary4.png" srcset="../images/list_item_primary4@2x.png 2x" />  |                                                                                                                                            |
+| Icon + Description + Label   | <img src="../images/list_item_primary5.png" srcset="../images/list_item_primary5@2x.png 2x" />  |                                                                                                                                            |
+| Icon + Label                 | <img src="../images/list_item_primary6.png" srcset="../images/list_item_primary6@2x.png 2x" />  |                                                                                                                                            |
+| Icon + Label + Description   | <img src="../images/list_item_primary7.png" srcset="../images/list_item_primary7@2x.png 2x" />  |                                                                                                                                            |
+| Label                        | <img src="../images/list_item_primary8.png" srcset="../images/list_item_primary8@2x.png 2x" />  |                                                                                                                                            |
+| Label + Description          | <img src="../images/list_item_primary9.png" srcset="../images/list_item_primary9@2x.png 2x" />  |                                                                                                                                            |
+| Label + Progress             | <img src="../images/list_item_primary10.png" srcset="../images/list_item_primary10@2x.png 2x" /> | Progress in a Primary Action can not have underlying text, therefore, the Text Style is set to None and this setting should not be changed |
 
 ### List Item Secondary Action
 
@@ -72,19 +72,19 @@ There are also many interchangable List Item Secondary Actions that are listed b
 
 |                  |                                         |                                                                                                                                       |
 | ---------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| Badge            | ![](../images/list_item_secondary.png)  |                                                                                                                                       |
-| Checkbox         | ![](../images/list_item_secondary2.png) | Checkbox in a Secondary Action can not have a label, therefore, the Label Style is set to None and this setting should not be changed |
-| Icons            | ![](../images/list_item_secondary3.png) |                                                                                                                                       |
-| Text             | ![](../images/list_item_secondary4.png) |                                                                                                                                       |
-| Text + Icons     | ![](../images/list_item_secondary5.png) |                                                                                                                                       |
-| Toggle           | ![](../images/list_item_secondary6.png) | Switch in a Secondary Action can not have a label, therefore, the Label Style is set to None and this setting should not be changed   |
-| Two-line Numbers | ![](../images/list_item_secondary7.png) |                                                                                                                                       |
+| Badge            | <img src="../images/list_item_secondary.png" srcset="../images/list_item_secondary@2x.png 2x" />  |                                                                                                                                       |
+| Checkbox         | <img src="../images/list_item_secondary2.png" srcset="../images/list_item_secondary2@2x.png 2x" /> | Checkbox in a Secondary Action can not have a label, therefore, the Label Style is set to None and this setting should not be changed |
+| Icons            | <img src="../images/list_item_secondary3.png" srcset="../images/list_item_secondary3@2x.png 2x" /> |                                                                                                                                       |
+| Text             | <img src="../images/list_item_secondary4.png" srcset="../images/list_item_secondary4@2x.png 2x" /> |                                                                                                                                       |
+| Text + Icons     | <img src="../images/list_item_secondary5.png" srcset="../images/list_item_secondary5@2x.png 2x" /> |                                                                                                                                       |
+| Toggle           | <img src="../images/list_item_secondary6.png" srcset="../images/list_item_secondary6@2x.png 2x" /> | Switch in a Secondary Action can not have a label, therefore, the Label Style is set to None and this setting should not be changed   |
+| Two-line Numbers | <img src="../images/list_item_secondary7.png" srcset="../images/list_item_secondary7@2x.png 2x" /> |                                                                                                                                       |
 
 ### Styling
 
 The List comes with styling flexibility through the overrides available for background color and the different elements used in the List Items, such as icons and text, as well as components like Avatar, Badge, Checkbox, Icon, Progress, Switch, etc. with their own styling capabilities.
 
-![](../images/list_styling.png)
+<img src="../images/list_styling.png" srcset="../images/list_styling@2x.png 2x" />
 
 ## Usage
 
@@ -92,9 +92,9 @@ The List and List Items have their own design specifics, but most importantly, o
 
 | Do                          | Don't                         |
 | --------------------------- | ----------------------------- |
-| ![](../images/list_do1.png) | ![](../images/list_dont1.png) |
-| ![](../images/list_do2.png) | ![](../images/list_dont2.png) |
-| ![](../images/list_do3.png) | ![](../images/list_dont3.png) |
+| <img src="../images/list_do1.png" srcset="../images/list_do1@2x.png 2x" /> | <img src="../images/list_dont1.png" srcset="../images/list_dont1@2x.png 2x" /> |
+| <img src="../images/list_do2.png" srcset="../images/list_do2@2x.png 2x" /> | <img src="../images/list_dont2.png" srcset="../images/list_dont2@2x.png 2x" /> |
+| <img src="../images/list_do3.png" srcset="../images/list_do3@2x.png 2x" /> | <img src="../images/list_dont3.png" srcset="../images/list_dont3@2x.png 2x" /> |
 
 ## Code generation
 

--- a/en/components/nav-drawer.md
+++ b/en/components/nav-drawer.md
@@ -10,20 +10,20 @@ Use the Navigation Drawer Component to implement application-level navigation by
 
 ### Navigation Drawer Demo
 
-![](../images/nav-drawer_demo.png)
+<img src="../images/nav-drawer_demo.png" srcset="../images/nav-drawer_demo@2x.png 2x" />
 
 ### Style
 
 The Navigation Drawer supports a **default** style with icon and label for each item and a mini style with icons only. If your design contains five or less items/views, you may pick between Navigation Drawer and [Bottom Navigation](bottom-nav.md).
 
-![](../images/nav-drawer_default.png)
-![](../images/nav-drawer_mini.png)
+<img src="../images/nav-drawer_default.png" srcset="../images/nav-drawer_default@2x.png 2x" />
+<img src="../images/nav-drawer_mini.png" srcset="../images/nav-drawer_mini@2x.png 2x" />
 
 ### Styling
 
 The Navigation Drawer provides basic styling capabilities achievable through changing the label and icon colors, as well as the active/inactive background colors.
 
-![](../images/nav-drawer_styling.png)
+<img src="../images/nav-drawer_styling.png" srcset="../images/nav-drawer_styling@2x.png 2x" />
 
 ## Usage
 
@@ -31,9 +31,9 @@ Navigation Drawer is always used as the main app navigation, therefore, position
 
 | Do                                | Don't                               |
 | --------------------------------- | ----------------------------------- |
-| ![](../images/nav-drawer_do1.png) | ![](../images/nav-drawer_dont1.png) |
-| ![](../images/nav-drawer_do2.png) | ![](../images/nav-drawer_dont2.png) |
-| ![](../images/nav-drawer_do3.png) | ![](../images/nav-drawer_dont3.png) |
+| <img src="../images/nav-drawer_do1.png" srcset="../images/nav-drawer_do1@2x.png 2x" /> | <img src="../images/nav-drawer_dont1.png" srcset="../images/nav-drawer_dont1@2x.png 2x" /> |
+| <img src="../images/nav-drawer_do2.png" srcset="../images/nav-drawer_do2@2x.png 2x" /> | <img src="../images/nav-drawer_dont2.png" srcset="../images/nav-drawer_dont2@2x.png 2x" /> |
+| <img src="../images/nav-drawer_do3.png" srcset="../images/nav-drawer_do3@2x.png 2x" /> | <img src="../images/nav-drawer_dont3.png" srcset="../images/nav-drawer_dont3@2x.png 2x" /> |
 
 ## Code generation
 

--- a/en/components/navbar.md
+++ b/en/components/navbar.md
@@ -10,30 +10,30 @@ Use the Navbar Component to provide clarity for the user about current position 
 
 ### Navbar Demo
 
-![](../images/navbar_demo.png)
+<img src="../images/navbar_demo.png" srcset="../images/navbar_demo@2x.png 2x" />
 
 ### Type
 
 The Navbar offers three layout configurations defined by the following types: **icon action and title**, text action and title, and title.
 
-![](../images/navbar_lefticon.png)
-![](../images/navbar_lefttext.png)
-![](../images/navbar_noleft.png)
+<img src="../images/navbar_lefticon.png" srcset="../images/navbar_lefticon@2x.png 2x" />
+<img src="../images/navbar_lefttext.png" srcset="../images/navbar_lefttext@2x.png 2x" />
+<img src="../images/navbar_noleft.png" srcset="../images/navbar_noleft@2x.png 2x" />
 
 ### Action Icons
 
 Every Navbar can support up to four action icons, rendered right to left, starting from the right edge of the screen that can trigger different simple events.
 
-![](../images/navbar_icon1.png)
-![](../images/navbar_icon2.png)
-![](../images/navbar_icon3.png)
-![](../images/navbar_icon4.png)
+<img src="../images/navbar_icon1.png" srcset="../images/navbar_icon1@2x.png 2x" />
+<img src="../images/navbar_icon2.png" srcset="../images/navbar_icon2@2x.png 2x" />
+<img src="../images/navbar_icon3.png" srcset="../images/navbar_icon3@2x.png 2x" />
+<img src="../images/navbar_icon4.png" srcset="../images/navbar_icon4@2x.png 2x" />
 
 ### Styling
 
 The Navbar comes with basic styling capabilities achievable through changing the title, icon, and background colors.
 
-![](../images/navbar_styling.png)
+<img src="../images/navbar_styling.png" srcset="../images/navbar_styling@2x.png 2x" />
 
 ## Usage
 
@@ -41,8 +41,8 @@ Navbar actions should be carefully used to avoid situations where they overlap w
 
 | Do                            | Don't                           |
 | ----------------------------- | ------------------------------- |
-| ![](../images/navbar_do1.png) | ![](../images/navbar_dont1.png) |
-| ![](../images/navbar_do2.png) | ![](../images/navbar_dont2.png) |
+| <img src="../images/navbar_do1.png" srcset="../images/navbar_do1@2x.png 2x" /> | <img src="../images/navbar_dont1.png" srcset="../images/navbar_dont1@2x.png 2x" /> |
+| <img src="../images/navbar_do2.png" srcset="../images/navbar_do2@2x.png 2x" /> | <img src="../images/navbar_dont2.png" srcset="../images/navbar_dont2@2x.png 2x" /> |
 
 ## Code generation
 

--- a/en/components/progress.md
+++ b/en/components/progress.md
@@ -10,14 +10,14 @@ Use the Progress Component to establish clarity and expectancy about the progres
 
 ### Progress Demo
 
-![](../images/progress_demo.png)
+<img src="../images/progress_demo.png" srcset="../images/progress_demo@2x.png 2x" />
 
 ### Type
 
 The Progress supports two layout types to fit the variety of use cases and layout requirements: a Circular Bar and a Linear Bar.
 
-![](../images/progress_circular.png)
-![](../images/progress_linear.png)
+<img src="../images/progress_circular.png" srcset="../images/progress_circular@2x.png 2x" />
+<img src="../images/progress_linear.png" srcset="../images/progress_linear@2x.png 2x" />
 
 ### State
 
@@ -29,19 +29,19 @@ The Progress can be used in one of the following preset color combinations:
 - error: utilizing the `error` theme color to show the progress
 - info: utilizing the `info` theme color to show the progress
 
-![](../images/progress_default.png)
-![](../images/progress_success.png)
-![](../images/progress_warn.png)
-![](../images/progress_error.png)
-![](../images/progress_info.png)
+<img src="../images/progress_default.png" srcset="../images/progress_default@2x.png 2x" />
+<img src="../images/progress_success.png" srcset="../images/progress_success@2x.png 2x" />
+<img src="../images/progress_warn.png" srcset="../images/progress_warn@2x.png 2x" />
+<img src="../images/progress_error.png" srcset="../images/progress_error@2x.png 2x" />
+<img src="../images/progress_info.png" srcset="../images/progress_info@2x.png 2x" />
 
 ### Styling
 
 The Progress comes with styling flexibility through the various overrides for its text, as well as changing the colors of stripes, fill, and track.
 
-![](../images/progress_striped.png)
-![](../images/progress_clear.png)
-![](../images/progress_twocolor.png)
+<img src="../images/progress_striped.png" srcset="../images/progress_striped@2x.png 2x" />
+<img src="../images/progress_clear.png" srcset="../images/progress_clear@2x.png 2x" />
+<img src="../images/progress_twocolor.png" srcset="../images/progress_twocolor@2x.png 2x" />
 
 ## Usage
 
@@ -49,8 +49,8 @@ In a Circular Bar, always use the actual value for the text label and, when addi
 
 | Do                              | Don't                             |
 | ------------------------------- | --------------------------------- |
-| ![](../images/progress_do1.png) | ![](../images/progress_dont1.png) |
-| ![](../images/progress_do2.png) | ![](../images/progress_dont2.png) |
+| <img src="../images/progress_do1.png" srcset="../images/progress_do1@2x.png 2x" /> | <img src="../images/progress_dont1.png" srcset="../images/progress_dont1@2x.png 2x" /> |
+| <img src="../images/progress_do2.png" srcset="../images/progress_do2@2x.png 2x" /> | <img src="../images/progress_dont2.png" srcset="../images/progress_dont2@2x.png 2x" /> |
 
 ## Code Generation
 

--- a/en/components/radio-group.md
+++ b/en/components/radio-group.md
@@ -10,26 +10,26 @@ Use the Radio Group Component to allow exclusive selection for one item in a gro
 
 ### Radio Group Demo
 
-![](../images/radiogroup_demo.png)
+<img src="../images/radiogroup_demo.png" srcset="../images/radiogroup_demo@2x.png 2x" />
 
 ### Theme
 
 The Radio Group can be used styled in **dark** and light variants to assure good readability and contrast for both lighter and darker backgrounds. Make sure that all Radios are set to the same theme.
 
-![](../images/radiogroup_dark.png)
-![](../images/radiogroup_light.png)
+<img src="../images/radiogroup_dark.png" srcset="../images/radiogroup_dark@2x.png 2x" />
+<img src="../images/radiogroup_light.png" srcset="../images/radiogroup_light@2x.png 2x" />
 
 ### State
 
 Each Radio in the group provides **on** and off selection states with additional variants for a disabled interaction state.
 
-![](../images/radiogroup_states.png)
+<img src="../images/radiogroup_states.png" srcset="../images/radiogroup_states@2x.png 2x" />
 
 ### Styling
 
 The Radio Group comes with styling flexibility through the various overrides for each item's label style and color.
 
-![](../images/radiogroup_styling.png)
+<img src="../images/radiogroup_styling.png" srcset="../images/radiogroup_styling@2x.png 2x" />
 
 ## Usage
 
@@ -37,8 +37,8 @@ When extending a Radio Group with additional items, make sure that they are all 
 
 | Do                                | Don't                               |
 | --------------------------------- | ----------------------------------- |
-| ![](../images/radiogroup_do1.png) | ![](../images/radiogroup_dont1.png) |
-| ![](../images/radiogroup_do2.png) | ![](../images/radiogroup_dont2.png) |
+| <img src="../images/radiogroup_do1.png" srcset="../images/radiogroup_do1@2x.png 2x" /> | <img src="../images/radiogroup_dont1.png" srcset="../images/radiogroup_dont1@2x.png 2x" /> |
+| <img src="../images/radiogroup_do2.png" srcset="../images/radiogroup_do2@2x.png 2x" /> | <img src="../images/radiogroup_dont2.png" srcset="../images/radiogroup_dont2@2x.png 2x" /> |
 
 ## Code generation
 

--- a/en/components/slider.md
+++ b/en/components/slider.md
@@ -10,34 +10,34 @@ Use the Slider Component to allow the user to select a single value or specify a
 
 ### Slider Demo
 
-![](../images/slider_demo.png)
+<img src="../images/slider_demo.png" srcset="../images/slider_demo@2x.png 2x" />
 
 ### Type
 
 The Slider offers a variant with one thumb for selecting a single value and with two thumbs for specifying a range.
 
-![](../images/slider_one-thumb.png)
-![](../images/slider_two-thumb.png)
+<img src="../images/slider_one-thumb.png" srcset="../images/slider_one-thumb@2x.png 2x" />
+<img src="../images/slider_two-thumb.png" srcset="../images/slider_two-thumb@2x.png 2x" />
 
 ### Theme
 
 The Slider can be used styled in **dark** or light theme to assure good readability and contrast for both lighter and darker backgrounds.
 
-![](../images/slider_dark.png)
-![](../images/slider_light.png)
+<img src="../images/slider_dark.png" srcset="../images/slider_dark@2x.png 2x" />
+<img src="../images/slider_light.png" srcset="../images/slider_light@2x.png 2x" />
 
 ### State
 
 The Slider supports **enabled** and disabled states, reflecting the possibility to change the value(s).
 
-![](../images/slider_enabled.png)
-![](../images/slider_disabled.png)
+<img src="../images/slider_enabled.png" srcset="../images/slider_enabled@2x.png 2x" />
+<img src="../images/slider_disabled.png" srcset="../images/slider_disabled@2x.png 2x" />
 
 ### Styling
 
 The Slider comes with styling flexibility through the overrides for the label background, thumb, track, and base track colors.
 
-![](../images/slider_styling.png)
+<img src="../images/slider_styling.png" srcset="../images/slider_styling@2x.png 2x" />
 
 ## Usage
 
@@ -45,8 +45,8 @@ The Slider track color should always have a higher emphasis than the track base 
 
 | Do                            | Don't                           |
 | ----------------------------- | ------------------------------- |
-| ![](../images/slider_do1.png) | ![](../images/slider_dont1.png) |
-| ![](../images/slider_do2.png) | ![](../images/slider_dont2.png) |
+| <img src="../images/slider_do1.png" srcset="../images/slider_do1@2x.png 2x" /> | <img src="../images/slider_dont1.png" srcset="../images/slider_dont1@2x.png 2x" /> |
+| <img src="../images/slider_do2.png" srcset="../images/slider_do2@2x.png 2x" /> | <img src="../images/slider_dont2.png" srcset="../images/slider_dont2@2x.png 2x" /> |
 
 ## Code generation
 

--- a/en/components/snackbar.md
+++ b/en/components/snackbar.md
@@ -10,13 +10,13 @@ Use the Snackbar Component to show a short notification or provide indication fo
 
 ### Snackbar Demo
 
-![](../images/snackbar_demo.png)
+<img src="../images/snackbar_demo.png" srcset="../images/snackbar_demo@2x.png 2x" />
 
 ### Styling
 
 The Snackbar comes with constrained styling flexibility, allowing only to change the text color of its action button.
 
-![](../images/snackbar_styling.png)
+<img src="../images/snackbar_styling.png" srcset="../images/snackbar_styling@2x.png 2x" />
 
 ## Usage
 
@@ -24,9 +24,9 @@ The Snackbar always appears on top of other content, so avoid placing on top of 
 
 | Do                              | Don't                             |
 | ------------------------------- | --------------------------------- |
-| ![](../images/snackbar_do1.png) | ![](../images/snackbar_dont1.png) |
-| ![](../images/snackbar_do2.png) | ![](../images/snackbar_dont2.png) |
-| ![](../images/snackbar_do3.png) | ![](../images/snackbar_dont3.png) |
+| <img src="../images/snackbar_do1.png" srcset="../images/snackbar_do1@2x.png 2x" /> | <img src="../images/snackbar_dont1.png" srcset="../images/snackbar_dont1@2x.png 2x" /> |
+| <img src="../images/snackbar_do2.png" srcset="../images/snackbar_do2@2x.png 2x" /> | <img src="../images/snackbar_dont2.png" srcset="../images/snackbar_dont2@2x.png 2x" /> |
+| <img src="../images/snackbar_do3.png" srcset="../images/snackbar_do3@2x.png 2x" /> | <img src="../images/snackbar_dont3.png" srcset="../images/snackbar_dont3@2x.png 2x" /> |
 
 ## Code generation
 

--- a/en/components/switch.md
+++ b/en/components/switch.md
@@ -10,36 +10,36 @@ Use the Switch Component to allow the user make a selection, which most often ex
 
 ### Switch Demo
 
-![](../images/switch_demo.png)
+<img src="../images/switch_demo.png" srcset="../images/switch_demo@2x.png 2x" />
 
 ### Theme
 
 The Switch can be used styled in **dark** and light variants to assure good readability and contrast for both lighter and darker backgrounds.
 
-![](../images/switch_dark.png)
-![](../images/switch_light.png)
+<img src="../images/switch_dark.png" srcset="../images/switch_dark@2x.png 2x" />
+<img src="../images/switch_light.png" srcset="../images/switch_light@2x.png 2x" />
 
 ### Label use
 
 The Switch is used **with** or without label. In order to hide the label, set its text value to a blank/space character and reduce the width of the component to e.g. 38px.
 
-![](../images/switch_label.png)
-![](../images/switch_no_label.png)
+<img src="../images/switch_label.png" srcset="../images/switch_label@2x.png 2x" />
+<img src="../images/switch_no_label.png" srcset="../images/switch_no_label@2x.png 2x" />
 
 ### State
 
 The Checkbox provides **on** and off selection states with additional variants for a disabled interaction state.
 
-![](../images/switch_on.png)
-![](../images/switch_on_disabled.png)
-![](../images/switch_off.png)
-![](../images/switch_off_disabled.png)
+<img src="../images/switch_on.png" srcset="../images/switch_on@2x.png 2x" />
+<img src="../images/switch_on_disabled.png" srcset="../images/switch_on_disabled@2x.png 2x" />
+<img src="../images/switch_off.png" srcset="../images/switch_off@2x.png 2x" />
+<img src="../images/switch_off_disabled.png" srcset="../images/switch_off_disabled@2x.png 2x" />
 
 ### Styling
 
 The Switch comes with styling flexibility, allowing control over the thumb and track colors. There is a fixed alpha value applied to the track to make it semi transparent.
 
-![](../images/switch_styling.png)
+<img src="../images/switch_styling.png" srcset="../images/switch_styling@2x.png 2x" />
 
 ## Usage
 
@@ -47,9 +47,9 @@ The Switch should appear to the right of the label describing the option, in reg
 
 | Do                            | Don't                           |
 | ----------------------------- | ------------------------------- |
-| ![](../images/switch_do1.png) | ![](../images/switch_dont1.png) |
-| ![](../images/switch_do2.png) | ![](../images/switch_dont2.png) |
-| ![](../images/switch_do3.png) | ![](../images/switch_dont3.png) |
+| <img src="../images/switch_do1.png" srcset="../images/switch_do1@2x.png 2x" /> | <img src="../images/switch_dont1.png" srcset="../images/switch_dont1@2x.png 2x" /> |
+| <img src="../images/switch_do2.png" srcset="../images/switch_do2@2x.png 2x" /> | <img src="../images/switch_dont2.png" srcset="../images/switch_dont2@2x.png 2x" /> |
+| <img src="../images/switch_do3.png" srcset="../images/switch_do3@2x.png 2x" /> | <img src="../images/switch_dont3.png" srcset="../images/switch_dont3@2x.png 2x" /> |
 
 ## Code Generation
 

--- a/en/components/tabs.md
+++ b/en/components/tabs.md
@@ -10,42 +10,42 @@ Use the Tabs Component to organize different views of the same information or sw
 
 ### Tabs Demo
 
-![](../images/tabs_demo.png)
+<img src="../images/tabs_demo.png" srcset="../images/tabs_demo@2x.png 2x" />
 
 ### Size
 
 The Tabs come arranged in a bar and can be either tall, showing icons with text, or short, containing either text or icons but not both at the same time.
 
-![](../images/tabs_short.png)
-![](../images/tabs_tall.png)
+<img src="../images/tabs_short.png" srcset="../images/tabs_short@2x.png 2x" />
+<img src="../images/tabs_tall.png" srcset="../images/tabs_tall@2x.png 2x" />
 
 ### Responsive
 
 The Tabs can be **fixed** and can fill up the available horizontal space by adapting their width or fluid, where scrolling buttons are provided to scroll in larger numbers of tabs. This allows for the fitting of more content that could normally fit in the available space with the other mode.
 
-![](../images/tabs_fixed.png)
-![](../images/tabs_fluid.png)
+<img src="../images/tabs_fixed.png" srcset="../images/tabs_fixed@2x.png 2x" />
+<img src="../images/tabs_fluid.png" srcset="../images/tabs_fluid@2x.png 2x" />
 
 ### Amount
 
 For the majority of scenarios, the Tabs need to contain between two and four tabs. If your case requires more than that, you may want to consider a fluid mode and represent only the tabs in view.
 
-![](../images/tabs_2.png)
-![](../images/tabs_3.png)
-![](../images/tabs_4.png)
+<img src="../images/tabs_2.png" srcset="../images/tabs_2@2x.png 2x" />
+<img src="../images/tabs_3.png" srcset="../images/tabs_3@2x.png 2x" />
+<img src="../images/tabs_4.png" srcset="../images/tabs_4@2x.png 2x" />
 
 ### Type
 
 The short Tabs support **text** and icon content modes to decribe the item in each tab.
 
-![](../images/tabs_text.png)
-![](../images/tabs_icons.png)
+<img src="../images/tabs_text.png" srcset="../images/tabs_text@2x.png 2x" />
+<img src="../images/tabs_icons.png" srcset="../images/tabs_icons@2x.png 2x" />
 
 ### Styling
 
 The Tabs provide basic styling capabilities achievable through changing the text and icon colors, the indicator color that marks the current selection, as well as the active/inactive background colors.
 
-![](../images/tabs_styling.png)
+<img src="../images/tabs_styling.png" srcset="../images/tabs_styling@2x.png 2x" />
 
 ## Usage
 
@@ -53,8 +53,8 @@ The Tabs are appropriate for organizing information, and one should avoid using 
 
 | Do                          | Don't                         |
 | --------------------------- | ----------------------------- |
-| ![](../images/tabs_do1.png) | ![](../images/tabs_dont1.png) |
-| ![](../images/tabs_do2.png) | ![](../images/tabs_dont2.png) |
+| <img src="../images/tabs_do1.png" srcset="../images/tabs_do1@2x.png 2x" /> | <img src="../images/tabs_dont1.png" srcset="../images/tabs_dont1@2x.png 2x" /> |
+| <img src="../images/tabs_do2.png" srcset="../images/tabs_do2@2x.png 2x" /> | <img src="../images/tabs_dont2.png" srcset="../images/tabs_dont2@2x.png 2x" /> |
 
 ## Code generation
 

--- a/en/components/text.md
+++ b/en/components/text.md
@@ -10,39 +10,39 @@ Use the Text Component Symbol to display the content of a title or paragraph str
 
 ### Text Demo
 
-![](../images/text_demo.png)
+<img src="../images/text_demo.png" srcset="../images/text_demo@2x.png 2x" />
 
 ### Title and Paragraph
 
 Text comes in two distict variants for Titles and for Paragraphs.
 
-![](../images/text_title.png)
-![](../images/text_paragraph.png)
+<img src="../images/text_title.png" srcset="../images/text_title@2x.png 2x" />
+<img src="../images/text_paragraph.png" srcset="../images/text_paragraph@2x.png 2x" />
 
 ### Title Sizes
 
 Text Titles come in six preset sizes from the largest H1 to the much smaller **H5** and H6.
 
-![](../images/text_h1.png)
-![](../images/text_h2.png)
-![](../images/text_h3.png)
-![](../images/text_h4.png)
-![](../images/text_h5.png)
-![](../images/text_h6.png)
+<img src="../images/text_h1.png" srcset="../images/text_h1@2x.png 2x" />
+<img src="../images/text_h2.png" srcset="../images/text_h2@2x.png 2x" />
+<img src="../images/text_h3.png" srcset="../images/text_h3@2x.png 2x" />
+<img src="../images/text_h4.png" srcset="../images/text_h4@2x.png 2x" />
+<img src="../images/text_h5.png" srcset="../images/text_h5@2x.png 2x" />
+<img src="../images/text_h6.png" srcset="../images/text_h6@2x.png 2x" />
 
 ### Paragraph Sizes
 
 Text Paragraphs come in three preset sizes: a larger **Body 1**, a smaller Body 2, and a tiny Caption used to annotate images and titles.
 
-![](../images/text_b1.png)
-![](../images/text_b2.png)
-![](../images/text_caption.png)
+<img src="../images/text_b1.png" srcset="../images/text_b1@2x.png 2x" />
+<img src="../images/text_b2.png" srcset="../images/text_b2@2x.png 2x" />
+<img src="../images/text_caption.png" srcset="../images/text_caption@2x.png 2x" />
 
 ### Styling
 
 Titles and Paragraphs come with constrained styling flexibility, allowing only to choose from the text weight and color presets available in the Typography portion of the Styling library.
 
-![](../images/text_styling.png)
+<img src="../images/text_styling.png" srcset="../images/text_styling@2x.png 2x" />
 
 ## Usage
 
@@ -50,8 +50,8 @@ Always choose Paragraph text color that makes a Hyperlink stand out if the two a
 
 | Do                          | Don't                         |
 | --------------------------- | ----------------------------- |
-| ![](../images/text_do1.png) | ![](../images/text_dont1.png) |
-| ![](../images/text_do2.png) | ![](../images/text_dont2.png) |
+| <img src="../images/text_do1.png" srcset="../images/text_do1@2x.png 2x" /> | <img src="../images/text_dont1.png" srcset="../images/text_dont1@2x.png 2x" /> |
+| <img src="../images/text_do2.png" srcset="../images/text_do2@2x.png 2x" /> | <img src="../images/text_dont2.png" srcset="../images/text_dont2@2x.png 2x" /> |
 
 ## Code generation
 

--- a/en/components/time-picker.md
+++ b/en/components/time-picker.md
@@ -10,34 +10,34 @@ Use the Time Picker Component to represent a date's time portion (hours and minu
 
 ### Time Picker Demo
 
-![](../images/timepicker_demo.png)
+<img src="../images/timepicker_demo.png" srcset="../images/timepicker_demo@2x.png 2x" />
 
 ### Layout
 
 The Time Picker supports Horizontal and Vertical time picking modes.
 
-![](../images/timepicker_horizontal.png)
-![](../images/timepicker_vertical.png)
+<img src="../images/timepicker_horizontal.png" srcset="../images/timepicker_horizontal@2x.png 2x" />
+<img src="../images/timepicker_vertical.png" srcset="../images/timepicker_vertical@2x.png 2x" />
 
 ### Buttons
 
 The Time Picker comes with two buttons: one for canceling the selection, which would revert the time to the original one, and one for confirming the selection, which would save the changes made. Upon setting both to none through the Overrides, a buttonless layout can be achieved.
 
-![](../images/timepicker_buttons.png)
-![](../images/timepicker_nobuttons.png)
+<img src="../images/timepicker_buttons.png" srcset="../images/timepicker_buttons@2x.png 2x" />
+<img src="../images/timepicker_nobuttons.png" srcset="../images/timepicker_nobuttons@2x.png 2x" />
 
 ### Content
 
 The Time Picker supports both 12 and 24 hour formats through two distinct content modes. Besides the hour and minute portion, the 12-hour content mode provides a meridiem portion, where selection between AM and PM is possible.
 
-![](../images/timepicker_12.png)
-![](../images/timepicker_24.png)
+<img src="../images/timepicker_12.png" srcset="../images/timepicker_12@2x.png 2x" />
+<img src="../images/timepicker_24.png" srcset="../images/timepicker_24@2x.png 2x" />
 
 ### Styling
 
 The Time Picker comes with styling flexibility through the various overrides controlling header background and title colors, as well as text colors for the selected hour, minute, and meridiem (AM/PM). The Cancel and OK buttons are Flat Buttons and can be styled accordingly.
 
-![](../images/timepicker_styling.png)
+<img src="../images/timepicker_styling.png" srcset="../images/timepicker_styling@2x.png 2x" />
 
 ## Usage
 
@@ -45,8 +45,8 @@ Show the Horizontal and Vertical Time Pickers as a dialog that dims the rest of 
 
 | Do                                | Don't                               |
 | --------------------------------- | ----------------------------------- |
-| ![](../images/timepicker_do1.png) | ![](../images/timepicker_dont1.png) |
-| ![](../images/timepicker_do2.png) | ![](../images/timepicker_dont2.png) |
+| <img src="../images/timepicker_do1.png" srcset="../images/timepicker_do1@2x.png 2x" /> | <img src="../images/timepicker_dont1.png" srcset="../images/timepicker_dont1@2x.png 2x" /> |
+| <img src="../images/timepicker_do2.png" srcset="../images/timepicker_do2@2x.png 2x" /> | <img src="../images/timepicker_dont2.png" srcset="../images/timepicker_dont2@2x.png 2x" /> |
 
 ## Code generation
 

--- a/en/components/toast.md
+++ b/en/components/toast.md
@@ -10,21 +10,21 @@ Use the Toast Component to show a short information message or notification, whi
 
 ### Toast Demo
 
-![](../images/toast_demo.png)
+<img src="../images/toast_demo.png" srcset="../images/toast_demo@2x.png 2x" />
 
 ### Position
 
 The Toast should be relatively positioned towards the bottom, center, or top of the content its information concerns.
 
-![](../images/toast_bottom.png)
-![](../images/toast_center.png)
-![](../images/toast_top.png)
+<img src="../images/toast_bottom.png" srcset="../images/toast_bottom@2x.png 2x" />
+<img src="../images/toast_center.png" srcset="../images/toast_center@2x.png 2x" />
+<img src="../images/toast_top.png" srcset="../images/toast_top@2x.png 2x" />
 
 ### Styling
 
 The Toast comes with constrained styling possibility, allowing only control of the background and message text colors. However, it is highly advisable to choose between `white` and `grays.900` for the message text, whichever of the two gives better contrast with the background.
 
-![](../images/toast_styling.png)
+<img src="../images/toast_styling.png" srcset="../images/toast_styling@2x.png 2x" />
 
 ## Usage
 
@@ -32,8 +32,8 @@ The Toast should always be centrally aligned on the horizontal and other placeme
 
 | Do                           | Don't                          |
 | ---------------------------- | ------------------------------ |
-| ![](../images/toast_do1.png) | ![](../images/toast_dont1.png) |
-| ![](../images/toast_do2.png) | ![](../images/toast_dont2.png) |
+| <img src="../images/toast_do1.png" srcset="../images/toast_do1@2x.png 2x" /> | <img src="../images/toast_dont1.png" srcset="../images/toast_dont1@2x.png 2x" /> |
+| <img src="../images/toast_do2.png" srcset="../images/toast_do2@2x.png 2x" /> | <img src="../images/toast_dont2.png" srcset="../images/toast_dont2@2x.png 2x" /> |
 
 ## Code Generation
 

--- a/en/getting-started.md
+++ b/en/getting-started.md
@@ -42,7 +42,7 @@ Now that you have added the Indigo Design Libraries, you are all set to start cr
     | &nbsp;&nbsp; Image | The image, which we will use as a background |
 
   <div class="divider--half"></div>
-  ![](images/getting-started1.png)
+  <img src="images/getting-started1.png" srcset="images/getting-started1@2x.png 2x" />
   <div class="divider--half"></div>
   <div class="divider--half"></div>
   <div class="divider--half"></div>
@@ -52,7 +52,7 @@ Now that you have added the Indigo Design Libraries, you are all set to start cr
 3.  From the insert menu, select `Indigo-Styling`, then `Shadows/Rect` and `Elevate 18` positioning it above the background, but below the Navbar. Do the same to insert a `Colors/white` rectangle and resize and position it so that its borders are aligned with all the borders of the elevation. Now select both layers and size them to 280 by 400, putting them in the exact center of the artboard to serve as a surface on top of which our form will be laid out.
 
   <div class="divider--half"></div>
-  ![](images/getting-started2.png)
+  <img src="images/getting-started2.png" srcset="images/getting-started2@2x.png 2x" />
   <div class="divider--half"></div>
   <div class="divider--half"></div>
   <div class="divider--half"></div>
@@ -62,7 +62,7 @@ Now that you have added the Indigo Design Libraries, you are all set to start cr
 4.  From the insert menu, select `Indigo-Components`, then `Text` and `Title` positioning it at the top of this surface with a 16px spacing on the left, top, and right. The newly inserted layer should appear above the surface, but below the Navbar. Set the Size override to H4 and the Style to ~34/left/Primary and for the Text type in "Start Budgeting". The last thing to do with this layer is to set its height to 56px.
 
   <div class="divider--half"></div>
-  ![](images/getting-started3.png)
+  <img src="images/getting-started3.png" srcset="images/getting-started3@2x.png 2x" />
   <div class="divider--half"></div>
   <div class="divider--half"></div>
   <div class="divider--half"></div>
@@ -72,7 +72,7 @@ Now that you have added the Indigo Design Libraries, you are all set to start cr
 5.  From the insert menu, select `Indigo-Components`, then `Inputs/Input` and `Line` positioning it below the title both in the canvas and in the layers panel. Leave 16px on the left, 0px from the Title at the top and set its width to 116px. Now duplicate this input, positioning the second one to the right of the first one, which will provide a 16px spacing between the two and on the right of the second one. Select both Inputs and change the State override to ~Dark/Filled. Then, with the left Input selected provide "First Name" for its label and "Eliza" for the Input Text. Do the same for the right one with "Last Name" and "Morales" and you should get something similar to this:
 
   <div class="divider--half"></div>
-  ![](images/getting-started4.png)
+  <img src="images/getting-started4.png" srcset="images/getting-started4@2x.png 2x" />
   <div class="divider--half"></div>
   <div class="divider--half"></div>
   <div class="divider--half"></div>
@@ -82,7 +82,7 @@ Now that you have added the Indigo Design Libraries, you are all set to start cr
 6.  Now, insert two more `Line` Inputs, positioning them one under the other, directly below the ones from the previous step. Change their State override to ~Dark/Filled as well and make them stretch across the full width with 16px spacing on both sides. Update the Labels to "Username" and "Password" and Input Texts to "Leaellynasaura" and "\*\*\*\*\*\*\*\*\*\*\*\*" accordingly.
 
   <div class="divider--half"></div>
-  ![](images/getting-started5.png)
+  <img src="images/getting-started5.png" srcset="images/getting-started5@2x.png 2x" />
   <div class="divider--half"></div>
   <div class="divider--half"></div>
   <div class="divider--half"></div>
@@ -92,7 +92,7 @@ Now that you have added the Indigo Design Libraries, you are all set to start cr
 7.  From the insert menu, select `Indigo-Components`, then `Buttons` and `Raised` positioning it below the form we have created. Leave 16px on the left, 0px from the Inputs at the top and 16px on the right. Update the Text to "SIGN UP" and set the Background to Colors/info.
 
   <div class="divider--half"></div>
-  ![](images/getting-started6.png)
+  <img src="images/getting-started6.png" srcset="images/getting-started6@2x.png 2x" />
   <div class="divider--half"></div>
   <div class="divider--half"></div>
   <div class="divider--half"></div>
@@ -102,7 +102,7 @@ Now that you have added the Indigo Design Libraries, you are all set to start cr
 8.  From the insert menu, select `Indigo-Components`, then `Text` and `Paragraph` positioning it below the button and changing its size so that there is a 16px spacing on all sides. Set the Size override to Body 2 and the Style to ~14/left/grays.700 and for the Text type in "By clicking on the "SIGN UP" button above, you accept our Terms of Use".
 
   <div class="divider--half"></div>
-  ![](images/getting-started7.png)
+  <img src="images/getting-started7.png" srcset="images/getting-started7@2x.png 2x" />
   <div class="divider--half"></div>
   <div class="divider--half"></div>
   <div class="divider--half"></div>

--- a/en/patterns/av.md
+++ b/en/patterns/av.md
@@ -8,8 +8,8 @@ _keywords: Design Systems, Design Systems UX, UI kit, Sketch, Ignite UI for Angu
 
 Use the AV Pattern to complement a represenatation of an audio or video track with playback controls.
 
-![](../images/av_player_demo.png)
-![](../images/av_volume_demo.png)
+<img src="../images/av_player_demo.png" srcset="../images/av_player_demo@2x.png 2x" />
+<img src="../images/av_volume_demo.png" srcset="../images/av_volume_demo@2x.png 2x" />
 
 The AV Pattern comes with the styling flexibility provided by the Icon Buttons and Linear Progress Bar that shape its layout.
 

--- a/en/patterns/avatar-badge.md
+++ b/en/patterns/avatar-badge.md
@@ -8,7 +8,7 @@ _keywords: Design Systems, Design Systems UX, UI kit, Sketch, Ignite UI for Angu
 
 Use the Avatar + Badge Pattern to complement the graphical representation that the Avatar provides with a short subtle message or indication for an alert or notification.
 
-![](../images/avatar_badge_demo.png)
+<img src="../images/avatar_badge_demo.png" srcset="../images/avatar_badge_demo@2x.png 2x" />
 
 The Avatar + Badge Pattern comes with the styling flexibility provided by the Avatar and Badge that constitute its layout.
 
@@ -24,7 +24,7 @@ The Avatar + Badge Pattern supports the same sizes that the Avatar does:
 
 The Badge can be positioned in any of the four corners of the Avatar as shown below through the help of an override.
 
-![](../images/avatar_badge_positions.png)
+<img src="../images/avatar_badge_positions.png" srcset="../images/avatar_badge_positions@2x.png 2x" />
 
 ## Additional Resources
 

--- a/en/patterns/card-collection.md
+++ b/en/patterns/card-collection.md
@@ -8,10 +8,10 @@ _keywords: Design Systems, Design Systems UX, UI kit, Sketch, Ignite UI for Angu
 
 Use the Card Collection Pattern to display an assistant or news feeds, as well as timelines and multi-column boards.
 
-![](../images/cardcol_demo_assistant.png)
-![](../images/cardcol_demo_news.png)
-![](../images/cardcol_demo_pins.png)
-![](../images/cardcol_demo_timeline.png)
+<img src="../images/cardcol_demo_assistant.png" srcset="../images/cardcol_demo_assistant@2x.png 2x" />
+<img src="../images/cardcol_demo_news.png" srcset="../images/cardcol_demo_news@2x.png 2x" />
+<img src="../images/cardcol_demo_pins.png" srcset="../images/cardcol_demo_pins@2x.png 2x" />
+<img src="../images/cardcol_demo_timeline.png" srcset="../images/cardcol_demo_timeline@2x.png 2x" />
 
 The Card Collection Pattern comes with the styling flexibility provided by the various types of Cards available and the Searchbar Input, where applicable.
 

--- a/en/patterns/checkbox-group.md
+++ b/en/patterns/checkbox-group.md
@@ -8,7 +8,7 @@ _keywords: Design Systems, Design Systems UX, UI kit, Sketch, Ignite UI for Angu
 
 Use the Checkbox Group Pattern to organize and layout a collection of Checkbox elements as a group, e.g. to contain the answers for a multiple choice question.
 
-![](../images/checkbox-group_demo.png)
+<img src="../images/checkbox-group_demo.png" srcset="../images/checkbox-group_demo@2x.png 2x" />
 
 > [!Note]
 > Trigger `Detach from Symbol` on an instance of the Checkbox Group Pattern only if you need to create more items than provided.

--- a/en/patterns/details.md
+++ b/en/patterns/details.md
@@ -8,7 +8,7 @@ _keywords: Design Systems, Design Systems UX, UI kit, Sketch, Ignite UI for Angu
 
 Use the Details Pattern to display detailed information as a full-screen page usually depicting things such as articles, products, recipes etc.
 
-![](../images/details_demo.png)
+<img src="../images/details_demo.png" srcset="../images/details_demo@2x.png 2x" />
 
 The Details Pattern comes with the styling flexibility provided by the Badges, Buttons, Tabs, and Text elements that constitute it.
 
@@ -16,7 +16,7 @@ The Details Pattern comes with the styling flexibility provided by the Badges, B
 
 The Details Pattern supports the following interchangeable pieces of content that, when combined, shape up its layout: Action Bar, Badge, Description, Metadata, Tabs, and Title and Price.
 
-![](../images/details_content.png)
+<img src="../images/details_content.png" srcset="../images/details_content@2x.png 2x" />
 
 ## Additional Resources
 

--- a/en/patterns/file-upload.md
+++ b/en/patterns/file-upload.md
@@ -8,7 +8,7 @@ _keywords: Design Systems, Design Systems UX, UI kit, Sketch, Ignite UI for Angu
 
 Use the File Upload Pattern to provide the uploading and insertion mechanisms for files, images, or attachments.
 
-![](../images/file-upload_demo.png)
+<img src="../images/file-upload_demo.png" srcset="../images/file-upload_demo@2x.png 2x" />
 
 The File Upload Pattern comes with the styling flexibility provided by the Avatar and Icon Button that constitute its layout.
 
@@ -16,13 +16,13 @@ The File Upload Pattern comes with the styling flexibility provided by the Avata
 
 The File Upload Pattern provides two types of previews for the uploaded file: an Avatar and a Document, shown in a standard image.
 
-![](../images/file-upload_type.png)
+<img src="../images/file-upload_type.png" srcset="../images/file-upload_type@2x.png 2x" />
 
 ### Content
 
 The File Upload Pattern supports the most common types of content that are usually uploaded or inserted as Documents: CSV, PDF, Presentation, Spreadsheet, and Text. Additionally, an Upload and Attach types are available to provide further flexibility for various appliction scenarios.
 
-![](../images/file-upload_content.png)
+<img src="../images/file-upload_content.png" srcset="../images/file-upload_content@2x.png 2x" />
 
 ## Additional Resources
 

--- a/en/patterns/form.md
+++ b/en/patterns/form.md
@@ -8,7 +8,7 @@ _keywords: Design Systems, Design Systems UX, UI kit, Sketch, Ignite UI for Angu
 
 Use the Form Pattern to create meaningful application scenarios, where the collection of user input is necessary. The various data entry and display Components are used to constitute some of the most common and meaningful Forms.
 
-![](../images/form_demo.png)
+<img src="../images/form_demo.png" srcset="../images/form_demo@2x.png 2x" />
 
 The Form Pattern comes with the styling flexibility provided by the Input, Checkbox, Button, Hyperlink, and Text that constitute its layout.
 
@@ -16,7 +16,7 @@ The Form Pattern comes with the styling flexibility provided by the Input, Check
 
 The Form Pattern is split in two main areas: an Inputs area with the main content for the various pieces of information that need to be filled in, and an Actions area where actions are laid out in rows, e.g. the "Terms of Use" or "Remember Me" Checkbox, the "Forgot Password?" link, and the Buttons for submitting the form. The Actions area is organized into three rows of interchangeable items that can be: Button, Checkbox, Link, Text Area, or Two Actions that appear as buttons by default but can be any combination of the items mentioned before.
 
-![](../images/form_content.png)
+<img src="../images/form_content.png" srcset="../images/form_content@2x.png 2x" />
 
 The Form Pattern provides various forms for some of the most common application scenarios such as: Login and Registration, Booking, Address, Payment, and New, allowing the user to add content.
 
@@ -24,32 +24,32 @@ The Form Pattern provides various forms for some of the most common application 
 
 The Login and Registration Forms are organized in two separate groups but they both have a "simpler" layout with meaningful Content and an Action Areas, as well as, a more elaborate layout with an additional Action Area for social login or registration.
 
-![](../images/form_login-simple.png)
-![](../images/form_login-social.png)
+<img src="../images/form_login-simple.png" srcset="../images/form_login-simple@2x.png 2x" />
+<img src="../images/form_login-social.png" srcset="../images/form_login-social@2x.png 2x" />
 
 The Login Form also comes with a Horizontal layout which can be customized for a Registration Form once the Button and Hyperlink content is updated accordingly. This layout is more appropriate for wide screens, where the form appears inline with other content.
 
-![](../images/form_login-horizontal.png)
-![](../images/form_register-horizontal.png)
+<img src="../images/form_login-horizontal.png" srcset="../images/form_login-horizontal@2x.png 2x" />
+<img src="../images/form_register-horizontal.png" srcset="../images/form_register-horizontal@2x.png 2x" />
 
 ##### Booking Forms
 
 There are four presets for Booking Forms, selectable through the Inputs override: Dates + People, which is rather generic; Dates + People + Rooms, which is appropriate for booking accommodation; Airports + Dates + People, which is best for booking airline tickets or other transportation; and Location + People + Rooms, which is again most suitable for booking an accommodation.
 
-![](../images/form_booking.png)
+<img src="../images/form_booking.png" srcset="../images/form_booking@2x.png 2x" />
 
 ##### New Forms
 
 There are two types of New Forms, selectable through the Inputs override: **Expense** for filling the information necessary to create a new expense, and Budget for filling the information necessary to allocate a new budget.
 
-![](../images/form_new.png)
+<img src="../images/form_new.png" srcset="../images/form_new@2x.png 2x" />
 
 ##### Payment Forms
 
 There are two main types of Payment forms: one for Card payments and one for Cash Transfers, like when you wire money through your online banking. The Cash Transfer Form provides four different layouts, selectable through the Inputs override: **Currency Exchange**, which has the necessary fields for currency conversion; Donation, which is suitable for charities; Between Accounts, which is usually the case for people holding multiple accounts in the same bank; and Between Banks, which is the common scenario for transferring money to another account under your or someone else's name.
 
-![](../images/form_card.png)
-![](../images/form_cash.png)
+<img src="../images/form_card.png" srcset="../images/form_card@2x.png 2x" />
+<img src="../images/form_cash.png" srcset="../images/form_cash@2x.png 2x" />
 
 ## Additional Resources
 

--- a/en/patterns/gallery.md
+++ b/en/patterns/gallery.md
@@ -8,19 +8,19 @@ _keywords: Design Systems, Design Systems UX, UI kit, Sketch, Ignite UI for Angu
 
 Use the Gallery Pattern to display an image grid where the images can also be organized in albums. It also has support for varoius image sizes:
 
-![](../images/gallery_large.png)
+<img src="../images/gallery_large.png" srcset="../images/gallery_large@2x.png 2x" />
 **Large** - _4 images per row_
 
-![](../images/gallery_medium.png)
+<img src="../images/gallery_medium.png" srcset="../images/gallery_medium@2x.png 2x" />
 Medium - _3 images per row_
 
-![](../images/gallery_small.png)
+<img src="../images/gallery_small.png" srcset="../images/gallery_small@2x.png 2x" />
 Small - _4 images per row_
 
-![](../images/gallery_very-small.png)
+<img src="../images/gallery_very-small.png" srcset="../images/gallery_very-small@2x.png 2x" />
 Very Small- _4 images per row_
 
-![](../images/gallery_flexible.png)
+<img src="../images/gallery_flexible.png" srcset="../images/gallery_flexible@2x.png 2x" />
 Flexible - _4 images per row_
 
 ## Additional Resources

--- a/en/patterns/image-manipulation.md
+++ b/en/patterns/image-manipulation.md
@@ -8,7 +8,7 @@ _keywords: Design Systems, Design Systems UX, UI kit, Sketch, Ignite UI for Angu
 
 Use the Image Manipulation Pattern to provide a way to edit, update, modify, or perform other quick actions on an image or Avatar containing a photo.
 
-![](../images/image-manip_demo.png)
+<img src="../images/image-manip_demo.png" srcset="../images/image-manip_demo@2x.png 2x" />
 
 The Image Manipulation Pattern comes with the styling flexibility provided by the Avatar and various Buttons that constitute its layout.
 
@@ -16,7 +16,7 @@ The Image Manipulation Pattern comes with the styling flexibility provided by th
 
 The Image Manipulation Pattern supports both standard images and Avatars that come in layouts with one or two Flat Buttons, FAB Button, or an Icon Button.
 
-![](../images/image-manip_layout.png)
+<img src="../images/image-manip_layout.png" srcset="../images/image-manip_layout@2x.png 2x" />
 
 ## Additional Resources
 

--- a/en/patterns/lists.md
+++ b/en/patterns/lists.md
@@ -8,9 +8,9 @@ _keywords: Design Systems, Design Systems UX, UI kit, Sketch, Ignite UI for Angu
 
 Use the Lists Pattern Symbols as presets for organized collections of data depicting common scenarios such as filterable settings, people, song playlists, products, searchable lists, and settings.
 
-![](../images/lists_people.png)
-![](../images/lists_products.png)
-![](../images/lists_settings.png)
+<img src="../images/lists_people.png" srcset="../images/lists_people@2x.png 2x" />
+<img src="../images/lists_products.png" srcset="../images/lists_products@2x.png 2x" />
+<img src="../images/lists_settings.png" srcset="../images/lists_settings@2x.png 2x" />
 
 The Lists Pattern comes with the styling flexibility provided by the various types of List Items available and the Searchbar Input, where applicable.
 

--- a/en/patterns/user-profile.md
+++ b/en/patterns/user-profile.md
@@ -8,8 +8,8 @@ _keywords: Design Systems, Design Systems UX, UI kit, Sketch, Ignite UI for Angu
 
 Use the User Profile Pattern to display user-related information, either as a full-screen detailed page or as a small indication that can be inserted in headers and toolbars.
 
-![](../images/profile_demo.png)
-![](../images/profile_small.png)
+<img src="../images/profile_demo.png" srcset="../images/profile_demo@2x.png 2x" />
+<img src="../images/profile_small.png" srcset="../images/profile_small@2x.png 2x" />
 
 An editable variant of the User Profile Pattern, nicely laid out with the appropriate Inputs, is also provided. The User Profile Pattern comes with the styling flexibility provided by the Avatar, Text, and Inputs that constitute its layout.
 

--- a/en/style/colors.md
+++ b/en/style/colors.md
@@ -8,13 +8,13 @@ _keywords: Design Systems, Design Systems UX, UI kit, Sketch, Ignite UI for Angu
 
 Use Colors to set up your theme's colors - `primary`, `secondary`, `success`, `warn`, `error`, `info`. The way Colors are set up in the Styling library is identical to the [Ignite UI for Angular Themes](https://www.infragistics.com/products/ignite-ui-angular/angular/components/themes.html).
 
-![](../images/colors_palette.png)
+<img src="../images/colors_palette.png" srcset="../images/colors_palette@2x.png 2x" />
 
 ### Palette Generation
 
 To change the primary color, navigate to the `Colors` page in the Sketch file and change the `Primary 500` symbol to a color of your choice. You will immediately see the whole primary palette instantly update. The same palette generation is available for the secondary color.
 
-![](../images/colors_generation.png)
+<img src="../images/colors_generation.png" srcset="../images/colors_generation@2x.png 2x" />
 
 > [!Note]
 > Since the text colors are controlled by the `Typography` to fully update the default theme, you also need to manually change the colors in the `Typography` page as well. Once you change your `primary` color, make sure you change the `Primary` section in Typography to the very same color. The exact steps to achieve this can be found in [Typography](typography.md).
@@ -28,13 +28,13 @@ In the cases where one needs more colors, besides the ones in the palette, it is
 If you want your added colors to be available across all the projects that use the libraries, follow these simple steps:
 
 1.  Open the Styling library, navigate to the `Colors` page, and zoom to the empty `Custom` section underneath the `black`, `white`, and `transparent` row of color symbols.
-    ![](../images/colors_custom0.png)
+    <img src="../images/colors_custom0.png" srcset="../images/colors_custom0@2x.png 2x" />
 
 2.  Select the `Colors/black` symbol and, while holding the `option` key drag the symbol below, create a copy of it.
-    ![](../images/colors_custom1.png)
+    <img src="../images/colors_custom1.png" srcset="../images/colors_custom1@2x.png 2x" />
 
 3.  Now, select the `Rectangle` layer, which happens to be the only layer of the `Colors/black copy` symbol, and change its Fill to a color of your choice e.g. #008080 (teal). Remember to also rename the symbol accordingly e.g. `Colors/teal`.
-    ![](../images/colors_custom2.png)
+    <img src="../images/colors_custom2.png" srcset="../images/colors_custom2@2x.png 2x" />
 
 4.  Save the changes to the library and now the color you have added should appear in the list of colors under the Styling library menu. It will also show up for the color overrides wherever colors are used in the Components and Patterns libraries.
 
@@ -43,16 +43,16 @@ If you want your added colors to be available across all the projects that use t
 The second approach describes the addition of file-specific colors, not available across all projects, but only in the current one in which you are working. To achieve that, follow these simple steps:
 
 1.  Open an existing or new Sketch file and create a new page, naming it `Local Styles`. Then, on the new page, insert a `Colors/black` element from the Styling library.
-    ![](../images/colors_local0.png)
+    <img src="../images/colors_local0.png" srcset="../images/colors_local0@2x.png 2x" />
 
 2.  Right click it and select `Detach from Symbol` to uncover this symbols-only contained layer called `Rectangle`. Select the `Rectangle` layer and change its Fill to a color of your choice e.g. #008080 (teal).
-    ![](../images/colors_local1.png)
+    <img src="../images/colors_local1.png" srcset="../images/colors_local1@2x.png 2x" />
 
 3.  Now, select the group that was formed after selecting `Detach from Symbol` (it should be called `Colors/black`, just like the symbol instance before) and click the `Create Symbol` button from the main Sketch menu at the top to reinstate the modified color as an overridable color symbol. In the prompt that will appear, choose a name for your custom color e.g. `Colors/teal` and make sure the Symbols Page checkbox is unselected before clicking the OK button. This will create the symbol and you should see something like this.
-    ![](../images/colors_local2.png)
+    <img src="../images/colors_local2.png" srcset="../images/colors_local2@2x.png 2x" />
 
 4.  Finally, let's do our housekeeping and remove the non-symbol rectangle with teal color, and we are all set. The color you have added should appear as a local symbol in the list of colors under the Document category. It will also show up for the color overrides under `Document/Colors` for all instances of Components and Patterns in the current project, where color is applicable.
-    ![](../images/colors_local3.png)
+    <img src="../images/colors_local3.png" srcset="../images/colors_local3@2x.png 2x" />
 
 ## Code generation
 

--- a/en/style/elevation.md
+++ b/en/style/elevation.md
@@ -18,7 +18,7 @@ There are 24 Elevations available in three distinct shapes:
 
 The higher the number of the Elevation, the more prominent the shadow. Shadows come as a combination of three stacked shadow colors, umbra, penumbra, and ambient, whose values match the Material Design definition.
 
-![](../images/elevation_people.png)
+<img src="../images/elevation_people.png" srcset="../images/elevation_people@2x.png 2x" />
 
 > [!Note]
 > Changing the Elevation in the Component overrides is possible in Sketch and will produce the expected outcome, but the same will not be achievable with Ignite UI for Angular yet.
@@ -27,7 +27,7 @@ The higher the number of the Elevation, the more prominent the shadow. Shadows c
 
 It is also possible to use Elevation on its own to lift one part of the content and draw more focus to it than the rest. In such scenarios, simply drag the Elevation of your choice and match it to the size of the content you would like to enhance.
 
-![](../images/elevation_standalone.png)
+<img src="../images/elevation_standalone.png" srcset="../images/elevation_standalone@2x.png 2x" />
 
 ## Additional Resources
 

--- a/en/style/material-icons.md
+++ b/en/style/material-icons.md
@@ -8,7 +8,7 @@ _keywords: Design Systems, Design Systems UX, UI kit, Sketch, Ignite UI for Angu
 
 Use the Material Icons to symbolize common actions in Icon Buttons, List Items, Cards etc. to reduce the amount of text that is normally used as a Button label for example. Material Icons consume the Colors Symbols in Styling, which lets you pick any of the defined colors for an Icon in the designs that you are crafting. The set of icons added to the Styling library is a subset of elements, identical to the [Material Icons](https://material.io/tools/icons/?style=baseline) and supported within [Ignite UI for Angular](https://www.infragistics.com/products/ignite-ui-angular).
 
-![](../images/icons_demo.png)
+<img src="../images/icons_demo.png" srcset="../images/icons_demo@2x.png 2x" />
 
 > [!Note]
 > The Components library provides dedicated [Icon](icon.md) symbol for four icon sizes: ExtraLarge, Large, Medium and Small. Use these when creating intricate layouts for articles, custom Cards and List Items etc. rather than the Styling library directly.
@@ -39,7 +39,7 @@ There is a set of 100+ Material Icons already available in the Styling library a
 With the preset collection of icons, you can design beautiful apps and pick the right symbolic representations for your Components and Patterns. Adding further icon sets is possible, but so is extending the current one with further Material Icons. Since [Ignite UI for Angular](https://www.infragistics.com/products/ignite-ui-angular) supports any Material Icon out there, this can be exactly what you are looking for. To do so, follow these simple steps:
 
 1.  First, navigate your browser to the [Material Design Icons Tool](https://material.io/tools/icons). Search for the icon you need, e.g. `copyright`, download it as an SVG, and note the category to which it belongs. In this case, would be `Action`. Now, open up the Styling library in Sketch and look if that same category exists as a text layer on the left. If it does not, create it and follow the steps below. If it does, which is our case for the `copyright` icon from the `Action` category, just find the right-most icon from that category and you should be looking at something like this.
-    ![](../images/icons_add1.png)
+    <img src="../images/icons_add1.png" srcset="../images/icons_add1@2x.png 2x" />
 
 2.  Now, duplicate the Symbol for this right-most icon and move it right a bit. Its name should end with `...Copy` and its structure should look like this within the overarching group named similarly to the Symbol.
     | Layer | Use |
@@ -48,13 +48,13 @@ With the preset collection of icons, you can design beautiful apps and pick the 
     | &nbsp;&nbsp; ↳ 🌈 Color | Defines the icon color |
     | &nbsp;&nbsp; Shape | Defines the icon shape |
     | &nbsp;&nbsp; Shape | Always a rectangle that defines the icon bounding box |
-    ![](../images/icons_add2.png)
+    <img src="../images/icons_add2.png" srcset="../images/icons_add2@2x.png 2x" />
 
 3.  Next, we want to replace the existing icon shape with the SVG we have downloaded, so we need to select the Shape layer with the icon shape and then drag and drop the SVG with the `copyright` icon on top of it. This will create a new group with the icon name in our layers panel, which we need to expand and drag the desired icon shape just outside of this group, but above the original icon shape.
-    ![](../images/icons_add3.png)
+    <img src="../images/icons_add3.png" srcset="../images/icons_add3@2x.png 2x" />
 
 4.  Let's remove the original icon shape now and the leftover group after moving the new icon shape out of it. Then, we have to select the one and only icon shape we have left with the `copyright` symbol and make sure it has neither borde, nor fill and is just used as a mask. After renaming the overarching group and the Symbol itself accordingly, e.g. to `copyright` and `Icons/action/copyright`, we are all set to use this icon just like any other one.
-    ![](../images/icons_add4.png)
+    <img src="../images/icons_add4.png" srcset="../images/icons_add4@2x.png 2x" />
 
 ## Additional Resources
 

--- a/en/style/styling-overview.md
+++ b/en/style/styling-overview.md
@@ -10,11 +10,11 @@ All Components map to Ignite UI for Angular components. The theming engine of In
 
 With the Sketch libraries, you're able to modify the NBL-Styling library to achieve the same results for both the Components and Patterns.
 
-![](../images/theme_overview_default.png)
+<img src="../images/theme_overview_default.png" srcset="../images/theme_overview_default@2x.png 2x" />
 
-![](../images/theme_overview_dark.png)
+<img src="../images/theme_overview_dark.png" srcset="../images/theme_overview_dark@2x.png 2x" />
 
-![](../images/theme_overview_vibrant.png)
+<img src="../images/theme_overview_vibrant.png" srcset="../images/theme_overview_vibrant@2x.png 2x" />
 
 ## NBL-Styling
 

--- a/en/style/typography.md
+++ b/en/style/typography.md
@@ -8,7 +8,7 @@ _keywords: Design Systems, Design Systems UX, UI kit, Sketch, Ignite UI for Angu
 
 Use Typography to set up your theme's typeface and available sizes. Although we are using [Titillium Web](https://fonts.google.com/specimen/Titillium+Web) as the default typeface, we really want to give every designer the flexibility to craft his applications with style. The essence of Typography in the Styling library is resonating with the way typography is implemented in the [Ignite UI for Angular Themes](https://www.infragistics.com/products/ignite-ui-angular/angular/components/themes.html).
 
-![](../images/typography_default.png)
+<img src="../images/typography_default.png" srcset="../images/typography_default@2x.png 2x" />
 
 > [!Note]
 > The Components library provides dedicated [Text](text.md) symbols for Titles and Paragraphs. Use these when creating intricate layouts for articles, blog posts etc. rather than the Styling library directly. Typography is meant to help you define a consistent theme and style for all the texts in your designs.
@@ -17,25 +17,25 @@ Use Typography to set up your theme's typeface and available sizes. Although we 
 
 Typography comes in multiple preset colors such as: `grays.900`, `grays.600`, `white`, `primary`, and `secondary`. There is also one additional set of specialty colors, containing Typography variations for strings that need to be in `success`, `warn`, and `error` colors, as well as a some additional nuances used by the components in the following section.
 
-![](../images/typography_colors.png)
+<img src="../images/typography_colors.png" srcset="../images/typography_colors@2x.png 2x" />
 
 ### Component specific typography
 
 Components, such as [Avatar](avatar.md), [Hyperlink](hyperlink.md), and [Text](text.md), use component-specific Typography to accommodate the specifics of the styling used by the respective component e.g. the Avatar needs a larger variety of colors, while the Hyperlink comes with an underlined text.
 
-![](../images/typography_specific.png)
+<img src="../images/typography_specific.png" srcset="../images/typography_specific@2x.png 2x" />
 
 ### Changing the typeface
 
 In order to change the typeface, hold the `command` key and drag across the whole Typography secton. This will select the text layers (otherwise you'll select the artboards). Now change the typeface to the one of your choice and you are all set.
 
-![](../images/typography_typeface.png)
+<img src="../images/typography_typeface.png" srcset="../images/typography_typeface@2x.png 2x" />
 
 ### Changing colors of typography
 
 Once you update the `primary` and `secondary` colors as the first step for theming your applications, you will see that the text colors will not update automatically. In order to update the text colors as well, hold the `command` key and drag across the whole `primary` or `secondary` section. This will select the text layers (otherwise you'll select the artboards). Now, change the text color to your color of choice and, after repeating this process for all necessary colors, your theme will be up to speed.
 
-![](../images/typography_primary.png)
+<img src="../images/typography_primary.png" srcset="../images/typography_primary@2x.png 2x" />
 
 > [!Note]
 > If you want to go one step further and e.g. use `grays.700` instead of `grays.600` besides following the process above to update the `grays.600` secton, you should also update the names of the affected layers to `Typography/.../grays.700`.

--- a/jp/codegen/after-codegen.md
+++ b/jp/codegen/after-codegen.md
@@ -41,7 +41,7 @@ RouterModule.forChild(routes)
 
 [RouterOutlet](https://angular.io/api/router/RouterOutlet) を追加した後、ターミナルで `npm start` を使用してアプリケーションを実行します。ブラウザーで URL にコンポーネント名を追加してサイトに移動します。
 
-![](../images/address-nav.png)
+<img src="../images/address-nav.png" srcset="../images/address-nav@2x.png 2x" />
 
 ここが開発の開始ポイントとなります。ここから開発者がアプリケーション要件に合わせるためにルートを変更できます。ボタン クリックなどの操作に基づいてナビゲーションをトリガーするコードを追加します。
 
@@ -53,7 +53,7 @@ RouterModule.forChild(routes)
 
 Sketch で、デザイナーが Nebula UI Category Chart コンポーネントをアートボードに追加します。
 
-![](../images/categorychart-overrides.png)
+<img src="../images/categorychart-overrides.png" srcset="../images/categorychart-overrides@2x.png 2x" />
 
 オーバーライドで DataSource オーバーライドがあります。指定した値は [Ignite UI for Angular](https://jp.infragistics.com/products/ignite-ui-angular) コントロールにバインドするプロパティをジェネレーターに指定します。この場合、Sketch のチャートは `igx-category-chart` に変換し、`dataSource` 入力は `olympicMedalData` にバインドします。
 

--- a/jp/components/avatar.md
+++ b/jp/components/avatar.md
@@ -11,7 +11,7 @@ Avatar コンポーネント シンボルは、プロフィール写真、アイ
 
 ### Avatar デモ
 
-![](../images/avatar_demo.png)
+<img src="../images/avatar_demo.png" srcset="../images/avatar_demo@2x.png 2x" />
 
 ### サイズ
 
@@ -21,23 +21,23 @@ Avatar のサイズは 3 つあります。
 - ミディアム - カスタム メニューや可視化に適しています。
 - スモール - コンタクト リストや繰り返しのシナリオに簡単に組み込めます。
 
-![](../images/avatar_sizes.png)
+<img src="../images/avatar_sizes.png" srcset="../images/avatar_sizes@2x.png 2x" />
 
 ### タイプ
 
 Avatar は、**画像**、イニシャルの文字列、アイコンなど、さまざまなタイプのコンテンツを使用できます。
 
-![](../images/avatar_content.png)
+<img src="../images/avatar_content.png" srcset="../images/avatar_content@2x.png 2x" />
 
 アバターは、**円形**と四角形の異なる 2 つの図形があります。
 
-![](../images/avatar_type.png)
+<img src="../images/avatar_type.png" srcset="../images/avatar_type@2x.png 2x" />
 
 ### スタイル設定
 
 Avatar は、さまざまなオーバーライドで背景色、イニシャルやアイコン色を制御することにより柔軟にスタイル設定できます。
 
-![](../images/avatar_styling.png)
+<img src="../images/avatar_styling.png" srcset="../images/avatar_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -45,7 +45,7 @@ Avatar でイニシャルやアイコンを使用する場合に Avatar 背景�
 
 | いい例                        | 悪い例                          |
 | ----------------------------- | ------------------------------- |
-| ![](../images/avatar_do1.png) | ![](../images/avatar_dont1.png) |
+| <img src="../images/avatar_do1.png" srcset="../images/avatar_do1@2x.png 2x" /> | <img src="../images/avatar_dont1.png" srcset="../images/avatar_dont1@2x.png 2x" /> |
 
 ## コードの生成
 

--- a/jp/components/badge.md
+++ b/jp/components/badge.md
@@ -11,25 +11,25 @@ Badge コンポーネント シンボルを使用して他のインターフェ�
 
 ### Badge デモ
 
-![](../images/badge_demo.png)
+<img src="../images/badge_demo.png" srcset="../images/badge_demo@2x.png 2x" />
 
 ### 図形
 
 Badge には、円形と四角形の 2 つの異なる図形があります。
 
-![](../images/badge_shapes.png)
+<img src="../images/badge_shapes.png" srcset="../images/badge_shapes@2x.png 2x" />
 
 ### タイプ
 
 Badge は、**数字**やアイコンなど、さまざまなタイプのコンテンツを使用できます。
 
-![](../images/badge_type.png)
+<img src="../images/badge_type.png" srcset="../images/badge_type@2x.png 2x" />
 
 ### スタイル設定
 
 Badge は、さまざまなオーバーライドで背景、境界線の色、元になるインターフェイス要素でキャストされた影の表示の制御などスタイル設定に柔軟性があります。
 
-![](../images/badge_styling.png)
+<img src="../images/badge_styling.png" srcset="../images/badge_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -37,7 +37,7 @@ Badge を使用して Avatar やテキスト タイトルなどのその他の U
 
 | いい例                           | 悪い例                         |
 | ---------------------------- | ------------------------------ |
-| ![](../images/badge_do1.png) | ![](../images/badge_dont1.png) |
+| <img src="../images/badge_do1.png" srcset="../images/badge_do1@2x.png 2x" /> | <img src="../images/badge_dont1.png" srcset="../images/badge_dont1@2x.png 2x" /> |
 
 ## コードの生成
 

--- a/jp/components/bottom-nav.md
+++ b/jp/components/bottom-nav.md
@@ -11,29 +11,29 @@ Bottom Navigation コンポーネント シンボルは、関連ビュー間の�
 
 ### Bottom Navigation デモ
 
-![](../images/bottom-nav_demo.png)
+<img src="../images/bottom-nav_demo.png" srcset="../images/bottom-nav_demo@2x.png 2x" />
 
 ### 項目数
 
 Bottom Navigation は 2 項目 ～ 5 項目をサポートします。アプリケーション レベルで 5 項目/ビュー以上のナビゲーションをデザインする場合は、[Navigation Drawer](nav-drawer.md) の使用を検討してください。
 
-![](../images/bottom-nav_items2.png)
-![](../images/bottom-nav_items3.png)
-![](../images/bottom-nav_items4.png)
-![](../images/bottom-nav_items5.png)
+<img src="../images/bottom-nav_items2.png" srcset="../images/bottom-nav_items2@2x.png 2x" />
+<img src="../images/bottom-nav_items3.png" srcset="../images/bottom-nav_items3@2x.png 2x" />
+<img src="../images/bottom-nav_items4.png" srcset="../images/bottom-nav_items4@2x.png 2x" />
+<img src="../images/bottom-nav_items5.png" srcset="../images/bottom-nav_items5@2x.png 2x" />
 
 ### 項目のスタイル
 
 Bottom Navigation 項目には、**アイコンとテキスト**の組み合わせ、またはアイコンのみが含まれます。常にアクティブな状態の項目が 1 つあり、残りの項目はインアクティブに設定する必要があります。
 
-![](../images/bottom-nav_icon&text.png)
-![](../images/bottom-nav_icon.png)
+<img src="../images/bottom-nav_icon&text.png" srcset="../images/bottom-nav_icon&text@2x.png 2x" />
+<img src="../images/bottom-nav_icon.png" srcset="../images/bottom-nav_icon@2x.png 2x" />
 
 ### スタイル設定
 
 Bottom Navigation は、さまざまなオーバーライドで背景色、項目ラベル、アイコン色を制御することにより柔軟にスタイル設定できます。
 
-![](../images/bottom-nav_styling.png)
+<img src="../images/bottom-nav_styling.png" srcset="../images/bottom-nav_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -41,8 +41,8 @@ Bottom Navigation は常にその他のコンテンツの一番上に表示さ�
 
 | いい例                                | 悪い例                               |
 | --------------------------------- | ----------------------------------- |
-| ![](../images/bottom-nav_do1.png) | ![](../images/bottom-nav_dont1.png) |
-| ![](../images/bottom-nav_do2.png) | ![](../images/bottom-nav_dont2.png) |
+| <img src="../images/bottom-nav_do1.png" srcset="../images/bottom-nav_do1@2x.png 2x" /> | <img src="../images/bottom-nav_dont1.png" srcset="../images/bottom-nav_dont1@2x.png 2x" /> |
+| <img src="../images/bottom-nav_do2.png" srcset="../images/bottom-nav_do2@2x.png 2x" /> | <img src="../images/bottom-nav_dont2.png" srcset="../images/bottom-nav_dont2@2x.png 2x" /> |
 
 ## その他のリソース
 

--- a/jp/components/button-group.md
+++ b/jp/components/button-group.md
@@ -11,35 +11,35 @@ Button Group コンポーネント シンボルは、関連する機能のトリ
 
 ### Button Group デモ
 
-![](../images/button-group_demo.png)
+<img src="../images/button-group_demo.png" srcset="../images/button-group_demo@2x.png 2x" />
 
 ### レイアウト
 
 Button Group は、2 方向レイアウトをサポートし、左から右の水平方向、上から下の垂直に配置できます。
 
-![](../images/button-group_horizontal.png)
-![](../images/button-group_vertical.png)
+<img src="../images/button-group_horizontal.png" srcset="../images/button-group_horizontal@2x.png 2x" />
+<img src="../images/button-group_vertical.png" srcset="../images/button-group_vertical@2x.png 2x" />
 
 ### ボタン数
 
 多くのケースで Button Group に 2 項目 ～ 4 項目が必要になります。4 項目以上必要な場合は、一連のリッチな操作を提供できるカスタム ツールバーをデザインすることを検討してください。
 
-![](../images/button-group_items2.png)
-![](../images/button-group_items3.png)
-![](../images/button-group_items4.png)
+<img src="../images/button-group_items2.png" srcset="../images/button-group_items2@2x.png 2x" />
+<img src="../images/button-group_items3.png" srcset="../images/button-group_items3@2x.png 2x" />
+<img src="../images/button-group_items4.png" srcset="../images/button-group_items4@2x.png 2x" />
 
 ### ボタン タイプ
 
 Button Group 内の各 Button には**テキスト**またはアイコンが含まれ、**デフォルト**、無効、ホバー、選択済みの状態で設定できます。選択済みの状態は、選択したボタンを分けるための追加の境界線があり、Button 配置に反映する必要のある 3 種類のバリアントが含まれます。
 
-![](../images/button-group_text.png)
-![](../images/button-group_icons.png)
+<img src="../images/button-group_text.png" srcset="../images/button-group_text@2x.png 2x" />
+<img src="../images/button-group_icons.png" srcset="../images/button-group_icons@2x.png 2x" />
 
 ### スタイル設定
 
 Button Group は、さまざまなオーバーライドで背景色、各ボタン境界線、背景、ラベル、アイコン色を制御することにより柔軟にスタイル設定できます。
 
-![](../images/button-group_styling.png)
+<img src="../images/button-group_styling.png" srcset="../images/button-group_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -47,9 +47,9 @@ Button のスタイルは統一させます。同じ Button グループ内で�
 
 | いい例                                  | 悪い例                                 |
 | ----------------------------------- | ------------------------------------- |
-| ![](../images/button-group_do1.png) | ![](../images/button-group_dont1.png) |
-| ![](../images/button-group_do2.png) | ![](../images/button-group_dont2.png) |
-| ![](../images/button-group_do3.png) | ![](../images/button-group_dont3.png) |
+| <img src="../images/button-group_do1.png" srcset="../images/button-group_do1@2x.png 2x" /> | <img src="../images/button-group_dont1.png" srcset="../images/button-group_dont1@2x.png 2x" /> |
+| <img src="../images/button-group_do2.png" srcset="../images/button-group_do2@2x.png 2x" /> | <img src="../images/button-group_dont2.png" srcset="../images/button-group_dont2@2x.png 2x" /> |
+| <img src="../images/button-group_do3.png" srcset="../images/button-group_do3@2x.png 2x" /> | <img src="../images/button-group_dont3.png" srcset="../images/button-group_dont3@2x.png 2x" /> |
 
 ## その他のリソース
 

--- a/jp/components/button.md
+++ b/jp/components/button.md
@@ -11,7 +11,7 @@ Button コンポーネント シンボルは、シンプルなユーザー操作
 
 ### Button デモ
 
-![](../images/button_demo.png)
+<img src="../images/button_demo.png" srcset="../images/button_demo@2x.png 2x" />
 
 ### タイプ
 
@@ -22,19 +22,19 @@ Button コンポーネント シンボルは、シンプルなユーザー操作
 - Icon Button は、操作をアイコンでのみ表されます。
 - Floating Action Button (fab) の塗りつぶしと影は、画面ごとに 1 回使用してメインの操作を強調します。
 
-![](../images/button_types.png)
+<img src="../images/button_types.png" srcset="../images/button_types@2x.png 2x" />
 
 ### 状態
 
 各ボタン タイプは**デフォルト**、ホバー、無効の状態をサポートします。アイコンやラベル付きのボタンはデフォルト状態でも利用できます。
 
-![](../images/button_states.png)
+<img src="../images/button_states.png" srcset="../images/button_states@2x.png 2x" />
 
 ### スタイル設定
 
 Button は、さまざまなオーバーライドで背景色、ラベル、アイコン色を制御することにより柔軟にスタイル設定できます。
 
-![](../images/button_styling.png)
+<img src="../images/button_styling.png" srcset="../images/button_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -42,9 +42,9 @@ Button のコンテンツにラベルを含む場合、大文字を太文字 (Me
 
 | いい例                            | 悪い例                           |
 | ----------------------------- | ------------------------------- |
-| ![](../images/button_do1.png) | ![](../images/button_dont1.png) |
-| ![](../images/button_do2.png) | ![](../images/button_dont2.png) |
-| ![](../images/button_do3.png) | ![](../images/button_dont3.png) |
+| <img src="../images/button_do1.png" srcset="../images/button_do1@2x.png 2x" /> | <img src="../images/button_dont1.png" srcset="../images/button_dont1@2x.png 2x" /> |
+| <img src="../images/button_do2.png" srcset="../images/button_do2@2x.png 2x" /> | <img src="../images/button_dont2.png" srcset="../images/button_dont2@2x.png 2x" /> |
+| <img src="../images/button_do3.png" srcset="../images/button_do3@2x.png 2x" /> | <img src="../images/button_dont3.png" srcset="../images/button_dont3@2x.png 2x" /> |
 
 ## コードの生成
 

--- a/jp/components/calendar.md
+++ b/jp/components/calendar.md
@@ -11,43 +11,43 @@ Calendar コンポーネントシンボルは、日付を視覚的に表して�
 
 ### Calendar デモ
 
-![](../images/calendar_demo.png)
+<img src="../images/calendar_demo.png" srcset="../images/calendar_demo@2x.png 2x" />
 
 ### レイアウト
 
 Calendar は、水平方向および垂直方向の日付選択モードをサポートします。基本のカレンダーはシンプルな表示とブラウジングを提供します。上記 2 つのコンポーネントはダイアログに使用しますが 2 つ目は他のコンテンツでインラインすることをお勧めします。
 
-![](../images/calendar_horizontal.png)
-![](../images/calendar_vertical.png)
-![](../images/calendar_base.png)
+<img src="../images/calendar_horizontal.png" srcset="../images/calendar_horizontal@2x.png 2x" />
+<img src="../images/calendar_vertical.png" srcset="../images/calendar_vertical@2x.png 2x" />
+<img src="../images/calendar_base.png" srcset="../images/calendar_base@2x.png 2x" />
 
 ### ボタン
 
 Calendar には 2 つのボタンがあります。1 つは選択されていた日付の変更を破棄するボタン、もう 1 つは今日に移動するためのボタンです。 Overrides で両方を none に設定してボタンレスのレイアウトを実現できます。
 
-![](../images/calendar_buttons.png)
-![](../images/calendar_nobuttons.png)
+<img src="../images/calendar_buttons.png" srcset="../images/calendar_buttons@2x.png 2x" />
+<img src="../images/calendar_nobuttons.png" srcset="../images/calendar_nobuttons@2x.png 2x" />
 
 ### コンテンツ
 
 Calendar では 3 つの主な日付部分 (年、月、日) の選択が可能です。コンテンツ モードが 3 つあり、各モードはそれぞれの日付部分を処理します。
 
-![](../images/calendar_days.png)
-![](../images/calendar_months.png)
-![](../images/calendar_years.png)
+<img src="../images/calendar_days.png" srcset="../images/calendar_days@2x.png 2x" />
+<img src="../images/calendar_months.png" srcset="../images/calendar_months@2x.png 2x" />
+<img src="../images/calendar_years.png" srcset="../images/calendar_years@2x.png 2x" />
 
 ### 週の初め
 
 週の初めは、最も一般的なシナリオ (日曜日または月曜日) から選択します。
 
-![](../images/calendar_sun.png)
-![](../images/calendar_mon.png)
+<img src="../images/calendar_sun.png" srcset="../images/calendar_sun@2x.png 2x" />
+<img src="../images/calendar_mon.png" srcset="../images/calendar_mon@2x.png 2x" />
 
 ### スタイル設定
 
 Calendar は、柔軟なスタイル設定が可能でさまざまなオーバーライドによりヘッダー背景、タイトル色、コンテンツの年月、年選択項目、選択した年/月/日のテキストや背景色を制御できます。Cancel と Today のボタンは、[Flat Buttons](button.md) で状況に応じたスタイル設定が可能です。
 
-![](../images/calendar_styling.png)
+<img src="../images/calendar_styling.png" srcset="../images/calendar_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -56,8 +56,8 @@ Calendar は、柔軟なスタイル設定が可能でさまざまなオーバ�
 
 | いい例                              | 悪い例                             |
 | ------------------------------- | --------------------------------- |
-| ![](../images/calendar_do1.png) | ![](../images/calendar_dont1.png) |
-| ![](../images/calendar_do2.png) | ![](../images/calendar_dont2.png) |
+| <img src="../images/calendar_do1.png" srcset="../images/calendar_do1@2x.png 2x" /> | <img src="../images/calendar_dont1.png" srcset="../images/calendar_dont1@2x.png 2x" /> |
+| <img src="../images/calendar_do2.png" srcset="../images/calendar_do2@2x.png 2x" /> | <img src="../images/calendar_dont2.png" srcset="../images/calendar_dont2@2x.png 2x" /> |
 
 ## その他のリソース
 

--- a/jp/components/cards-custom.md
+++ b/jp/components/cards-custom.md
@@ -11,7 +11,7 @@ Custom Card コンポーネントは、通常のカードと同じタイプの�
 
 ### Custom Card デモ
 
-![](../images/card_custom_demo.png)
+<img src="../images/card_custom_demo.png" srcset="../images/card_custom_demo@2x.png 2x" />
 
 ### シンボルからデタッチ
 
@@ -31,7 +31,7 @@ Card レイアウトをカスタマイズするには、`Cards/Custom` をアー
 
 Custom Card は、スタイルに高い柔軟性があり、テキスト、ボタン、背景色などのさまざまなオーバーライドによって通常の Card とマッチすることができます。シンボルからでタッチを使用して角丸やエレベーション レベルなどを追加で制御できます。
 
-![](../images/card_custom_styling.png)
+<img src="../images/card_custom_styling.png" srcset="../images/card_custom_styling@2x.png 2x" />
 
 | レイヤー | 使用 |
 | ----------------------------- | ---------------------------------------- |
@@ -44,33 +44,33 @@ Custom Card は、スタイルに高い柔軟性があり、テキスト、ボ�
 
 以下は、上記の天気 Card の複雑なレイアウトを 5 つのシンプルなステップで作成する方法です。空 Artboard に Custom Card をドラッグし、`シンボルからデタッチ`を選択して、背景色、角の半径、開始ポイントに必要なエレベーションを変更してベーシック スタイルを適用します。
 
-![](../images/card_custom_layout0.png)
+<img src="../images/card_custom_layout0.png" srcset="../images/card_custom_layout0@2x.png 2x" />
 
 1.  Header Style を再利用して Title と Subtitle Text の文字列を更新します。Content グループは後にして Actions Style へ移動します。ここでは、デフォルトで含まれる Icon Actions ではなく Button Actions へ変更します。最後に Left Button テキストを更新し、none に設定して Right Button を非表示にします。
 
-  ![](../images/card_custom_layout1.png)
+  <img src="../images/card_custom_layout1.png" srcset="../images/card_custom_layout1@2x.png 2x" />
 
 2.  Content に戻り、天気予報のレイアウトを作成します。はじめに Cards/Blocks/Header/Large Title (Card 領域グループですべてのブロック タイプを使用可能) を挿入し、タイトルを H1 Size に更新して、シンボルをタイトルおよびサブタイトルの両方を表示するためにサイズ変更します。文字列値を更新後、デフォルト段落 Content Style を削除でき、次のようになります (デフォルト Content Style は他の要素も保持するため、Content グループを保存します)。
 
-  ![](../images/card_custom_layout2.png)
+  <img src="../images/card_custom_layout2.png" srcset="../images/card_custom_layout2@2x.png 2x" />
 
 3.  次に太陽のイラストを Content Group に追加します。楕円形を数本の線形でグループ化してグループ幅と高さをプロパティ パネルで調整し、歪みを防止します。太陽イラストレーションを度タイトルの右に配置してレイアウトはこのようになります。
 
-  ![](../images/card_custom_layout3.png)
+  <img src="../images/card_custom_layout3.png" srcset="../images/card_custom_layout3@2x.png 2x" />
 
 4.  One-thumb Slider Component および Cards/Blocks/Content/Paragraph Text を下のラベル配列に追加します。ターゲットとするデザインにするために Slider を選択して Label Text Style および Label Background を none にオーバーライドし、ラベル バルーンを非表示にします。Paragraph Text にラベル値を挿入後、これと同様のことができます。
 
-  ![](../images/card_custom_layout4.png)
+  <img src="../images/card_custom_layout4.png" srcset="../images/card_custom_layout4@2x.png 2x" />
 
 5.  ここでは詳細な予報領域をデザインします。最も簡単な方法は Cards/Blocks/Content/Paragraph Text を 2 回挿入する方法です。1 回は平日用、1 回は度用です。これら 2 列のテキスト間に Small Icon を挿入後 4 回複製して垂直に配置した列をもう 1 列形成します。予測値で可視化を選択後、ターゲット レイアウトの完了です。
 
-  ![](../images/card_custom_layout5.png)
+  <img src="../images/card_custom_layout5.png" srcset="../images/card_custom_layout5@2x.png 2x" />
 
 #### 追加のスタイル
 
 Custom Card レイアウトでは、カードに挿入されている要素に基づいてさまざまなスタイルを追加することが可能になります。たとえば気温の色を設定して強調し、スライダー ラベルや平日ラベルの段落などの追加情報に薄い色を設定できます。
 
-![](../images/card_custom_layout_styled.png)
+<img src="../images/card_custom_layout_styled.png" srcset="../images/card_custom_layout_styled@2x.png 2x" />
 
 ## その他のリソース
 

--- a/jp/components/cards.md
+++ b/jp/components/cards.md
@@ -11,7 +11,7 @@ Card コンポーネントシンボルは、画像とテキストで単一オブ
 
 ### Card デモ
 
-![](../images/card_demo.png)
+<img src="../images/card_demo.png" srcset="../images/card_demo@2x.png 2x" />
 
 ### 領域
 
@@ -19,34 +19,34 @@ Card には 3 つの領域 (`header` - タイトルとサブタイトルの組�
 
 |         |                                       |
 | ------- | ------------------------------------- |
-| `header`  | ![](../images/card_headerL.png)       |
-| `content` | ![](../images/card_content_image.png) |
-| `actions` | ![](../images/card_actions_icons.png) |
+| `header`  | <img src="../images/card_headerL.png" srcset="../images/card_headerL@2x.png 2x" />       |
+| `content` | <img src="../images/card_content_image.png" srcset="../images/card_content_image@2x.png 2x" /> |
+| `actions` | <img src="../images/card_actions_icons.png" srcset="../images/card_actions_icons@2x.png 2x" /> |
 
 ### ヘッダー
 
 Card ヘッダーは、3 種類のレイアウト (**Large Title** - 大きいタイトルとサブタイトル、Small Title - スモール タイトルとサブタイトル、Small Title - スモール タイトルのみ (サブタイトルなし) をサポートします。
 
-![](../images/card_headerL.png)
-![](../images/card_headerS.png)
-![](../images/card_header_title.png)
+<img src="../images/card_headerL.png" srcset="../images/card_headerL@2x.png 2x" />
+<img src="../images/card_headerS.png" srcset="../images/card_headerS@2x.png 2x" />
+<img src="../images/card_header_title.png" srcset="../images/card_header_title@2x.png 2x" />
 
 ### コンテンツ
 
 Card コンテンツは、5 種類のレイアウト (連絡先のようなショートカットの**配列**、タイトルあり/なしの画像、地理的な位置を表すマップ、短い説明のテキストの段落) をサポートします。
 
-![](../images/card_content_shortcuts.png)
-![](../images/card_content_image.png)
-![](../images/card_content_map.png)
-![](../images/card_content_paragraph.png)
+<img src="../images/card_content_shortcuts.png" srcset="../images/card_content_shortcuts@2x.png 2x" />
+<img src="../images/card_content_image.png" srcset="../images/card_content_image@2x.png 2x" />
+<img src="../images/card_content_map.png" srcset="../images/card_content_map@2x.png 2x" />
+<img src="../images/card_content_paragraph.png" srcset="../images/card_content_paragraph@2x.png 2x" />
 
 ### 操作
 
 Card 操作は 3 種類のレイアウトをサポートします。Flat ボタン数個のみのある**ボタン操作**、アイコン操作 (アイコン 3 つ迄)、アイコンとボタン操作の 2 つの組み合わせ。
 
-![](../images/card_actions_buttons.png)
-![](../images/card_actions_icons.png)
-![](../images/card_actions_mixed.png)
+<img src="../images/card_actions_buttons.png" srcset="../images/card_actions_buttons@2x.png 2x" />
+<img src="../images/card_actions_icons.png" srcset="../images/card_actions_icons@2x.png 2x" />
+<img src="../images/card_actions_mixed.png" srcset="../images/card_actions_mixed@2x.png 2x" />
 
 ### タイプ
 
@@ -54,16 +54,16 @@ Card で以下のレイアウトのうちの 1 つを利用できます。
 
 |                   |                                       |
 | ----------------- | ------------------------------------- |
-| Point of Interest | ![](../images/card_poi.png)           |
-| Audio Video Card  | ![](../images/card_av.png)            |
-| Normal Pin        | ![](../images/card_normal-pin.png)    |
-| Condensed Pin     | ![](../images/card_condensed-pin.png) |
-| Shortcuts         | ![](../images/card_shortcuts.png)     |
-| Simple Card       | ![](../images/card_simple.png)        |
-| Small Card        | ![](../images/card_small.png)         |
-| Square Card       | ![](../images/card_square.png)        |
-| Text Card         | ![](../images/card_text.png)          |
-| Timeline Card     | ![](../images/card_timeline.png)      |
+| Point of Interest | <img src="../images/card_poi.png" srcset="../images/card_poi@2x.png 2x" />           |
+| Audio Video Card  | <img src="../images/card_av.png" srcset="../images/card_av@2x.png 2x" />            |
+| Normal Pin        | <img src="../images/card_normal-pin.png" srcset="../images/card_normal-pin@2x.png 2x" />    |
+| Condensed Pin     | <img src="../images/card_condensed-pin.png" srcset="../images/card_condensed-pin@2x.png 2x" /> |
+| Shortcuts         | <img src="../images/card_shortcuts.png" srcset="../images/card_shortcuts@2x.png 2x" />     |
+| Simple Card       | <img src="../images/card_simple.png" srcset="../images/card_simple@2x.png 2x" />        |
+| Small Card        | <img src="../images/card_small.png" srcset="../images/card_small@2x.png 2x" />         |
+| Square Card       | <img src="../images/card_square.png" srcset="../images/card_square@2x.png 2x" />        |
+| Text Card         | <img src="../images/card_text.png" srcset="../images/card_text@2x.png 2x" />          |
+| Timeline Card     | <img src="../images/card_timeline.png" srcset="../images/card_timeline@2x.png 2x" />      |
 
 デザインに合わない場合は、[カスタム カード](cards-custom.md)を作成できます。
 
@@ -71,7 +71,7 @@ Card で以下のレイアウトのうちの 1 つを利用できます。
 
 Card は、さまざまなオーバーライドでヘッダー、コンテンツ、テキスト、アイコン、ボタンの色などの操作領域の制御やカードの背景色の選択などスタイル設定に柔軟性があります。
 
-![](../images/card_styling.png)
+<img src="../images/card_styling.png" srcset="../images/card_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -79,8 +79,8 @@ Card はより詳細な情報についての概要やエントリ ポイント�
 
 | いい例                          | 悪い例                         |
 | --------------------------- | ----------------------------- |
-| ![](../images/card_do1.png) | ![](../images/card_dont1.png) |
-| ![](../images/card_do2.png) | ![](../images/card_dont2.png) |
+| <img src="../images/card_do1.png" srcset="../images/card_do1@2x.png 2x" /> | <img src="../images/card_dont1.png" srcset="../images/card_dont1@2x.png 2x" /> |
+| <img src="../images/card_do2.png" srcset="../images/card_do2@2x.png 2x" /> | <img src="../images/card_dont2.png" srcset="../images/card_dont2@2x.png 2x" /> |
 
 ## その他のリソース
 

--- a/jp/components/carousel.md
+++ b/jp/components/carousel.md
@@ -11,13 +11,13 @@ Carousel コンポーネント シンボルは、横矢印キーを使用して�
 
 ### Carousel デモ
 
-![](../images/carousel_demo.png)
+<img src="../images/carousel_demo.png" srcset="../images/carousel_demo@2x.png 2x" />
 
 ### スタイル設定
 
 Carousel は、さまざまなオーバーライドでナビゲーションボタンの背景、アイコンの色、インジケーターの色、境界線の色、現在アクティブなスライドのスライド画像の制御などスタイル設定に柔軟性があります。一度に 1 インジケーターのみアクティブにできます。
 
-![](../images/carousel_styling.png)
+<img src="../images/carousel_styling.png" srcset="../images/carousel_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -25,8 +25,8 @@ Carousel の戻るおよび次へ移動するためのボタンは、常に画�
 
 | いい例                              | 悪い例                             |
 | ------------------------------- | --------------------------------- |
-| ![](../images/carousel_do1.png) | ![](../images/carousel_dont1.png) |
-| ![](../images/carousel_do2.png) | ![](../images/carousel_dont2.png) |
+| <img src="../images/carousel_do1.png" srcset="../images/carousel_do1@2x.png 2x" /> | <img src="../images/carousel_dont1.png" srcset="../images/carousel_dont1@2x.png 2x" /> |
+| <img src="../images/carousel_do2.png" srcset="../images/carousel_do2@2x.png 2x" /> | <img src="../images/carousel_dont2.png" srcset="../images/carousel_dont2@2x.png 2x" /> |
 
 ## その他のリソース
 

--- a/jp/components/chart-category.md
+++ b/jp/components/chart-category.md
@@ -11,14 +11,14 @@ Category Chart コンポーネント シンボルは、密度をラップして�
 
 ### Category Chart デモ
 
-![](../images/category_chart_demo.png)
+<img src="../images/category_chart_demo.png" srcset="../images/category_chart_demo@2x.png 2x" />
 
 ### ツールチップ
 
 Category Chart は、ツールチップ表示のオーバーライドが可能です。ツールチップを非表示にする **Tooltip Off**、シリーズの一番上に表示する Tooltip On。
 
-![](../images/chart_category_tooltip-off.png)
-![](../images/chart_category_tooltip-on.png)
+<img src="../images/chart_category_tooltip-off.png" srcset="../images/chart_category_tooltip-off@2x.png 2x" />
+<img src="../images/chart_category_tooltip-on.png" srcset="../images/chart_category_tooltip-on@2x.png 2x" />
 
 ### タイプ
 
@@ -26,15 +26,15 @@ Category Chart は以下のようなさまざまなオーバーライドで Char
 
 |             |                                               |
 | ----------- | --------------------------------------------- |
-| エリア        | ![](../images/chart_category_area.png)        |
-| 柱状      | ![](../images/chart_category_column.png)      |
-| 折れ線        | ![](../images/chart_category_line.png)        |
-| ポイント       | ![](../images/chart_category_point.png)       |
-| スプライン      | ![](../images/chart_category_spline.png)      |
-| スプライン エリア | ![](../images/chart_category_spline-area.png) |
-| ステップ エリア   | ![](../images/chart_category_step-area.png)   |
-| ステップ折れ線   | ![](../images/chart_category_step-line.png)   |
-| ウォーターフォール   | ![](../images/chart_category_waterfall.png)   |
+| エリア        | <img src="../images/chart_category_area.png" srcset="../images/chart_category_area@2x.png 2x" />        |
+| 柱状      | <img src="../images/chart_category_column.png" srcset="../images/chart_category_column@2x.png 2x" />      |
+| 折れ線        | <img src="../images/chart_category_line.png" srcset="../images/chart_category_line@2x.png 2x" />        |
+| ポイント       | <img src="../images/chart_category_point.png" srcset="../images/chart_category_point@2x.png 2x" />       |
+| スプライン      | <img src="../images/chart_category_spline.png" srcset="../images/chart_category_spline@2x.png 2x" />      |
+| スプライン エリア | <img src="../images/chart_category_spline-area.png" srcset="../images/chart_category_spline-area@2x.png 2x" /> |
+| ステップ エリア   | <img src="../images/chart_category_step-area.png" srcset="../images/chart_category_step-area@2x.png 2x" />   |
+| ステップ折れ線   | <img src="../images/chart_category_step-line.png" srcset="../images/chart_category_step-line@2x.png 2x" />   |
+| ウォーターフォール   | <img src="../images/chart_category_waterfall.png" srcset="../images/chart_category_waterfall@2x.png 2x" />   |
 
 ## 使用方法
 
@@ -42,7 +42,7 @@ Category Chart は以下のようなさまざまなオーバーライドで Char
 
 | いい例                                   | 悪い例                                   |
 | ------------------------------------- | --------------------------------------- |
-| ![](../images/chart_category_do1.png) | ![](../images/chart_category_dont1.png) |
+| <img src="../images/chart_category_do1.png" srcset="../images/chart_category_do1@2x.png 2x" /> | <img src="../images/chart_category_dont1.png" srcset="../images/chart_category_dont1@2x.png 2x" /> |
 
 ## コードの生成
 

--- a/jp/components/checkbox.md
+++ b/jp/components/checkbox.md
@@ -11,27 +11,27 @@ Checkbox コンポーネント シンボルは、設定の変更やフォーム�
 
 ### Checkbox デモ
 
-![](../images/checkbox_demo.png)
+<img src="../images/checkbox_demo.png" srcset="../images/checkbox_demo@2x.png 2x" />
 
 ### テーマ
 
 Checkbox は、明暗バリアントで分かりやすく、背景に明暗のコントラストを付けてスタイル設定できます。
 
-![](../images/checkbox_dark.png)
-![](../images/checkbox_light.png)
+<img src="../images/checkbox_dark.png" srcset="../images/checkbox_dark@2x.png 2x" />
+<img src="../images/checkbox_light.png" srcset="../images/checkbox_light@2x.png 2x" />
 
 ### 状態
 
 Checkbox は、**オン**/オフと不確定状態があり、追加のバリアントとしてインタラクション無効の状態があります。
 
-![](../images/checkbox_states.png)
-![](../images/checkbox_selection.png)
+<img src="../images/checkbox_states.png" srcset="../images/checkbox_states@2x.png 2x" />
+<img src="../images/checkbox_selection.png" srcset="../images/checkbox_selection@2x.png 2x" />
 
 ### スタイル設定
 
 Checkbox は、さまざまなオーバーライドでチェック、色の塗りつぶし、ラベル テキストの色を制御することにより柔軟にスタイル設定できます。
 
-![](../images/calendar_styling.png)
+<img src="../images/calendar_styling.png" srcset="../images/calendar_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -39,7 +39,7 @@ Checkbox は、さまざまなオーバーライドでチェック、色の塗�
 
 | いい例                             | 悪い例                             |
 | ------------------------------- | --------------------------------- |
-| ![](../images/checkbox_do1.png) | ![](../images/checkbox_dont1.png) |
+| <img src="../images/checkbox_do1.png" srcset="../images/checkbox_do1@2x.png 2x" /> | <img src="../images/checkbox_dont1.png" srcset="../images/checkbox_dont1@2x.png 2x" /> |
 
 ## コードの生成
 

--- a/jp/components/dialog.md
+++ b/jp/components/dialog.md
@@ -11,21 +11,21 @@ Dialog コンポーネント シンボルは、メッセージや警告をユー
 
 ### Dialog デモ
 
-![](../images/dialog_demo.png)
+<img src="../images/dialog_demo.png" srcset="../images/dialog_demo@2x.png 2x" />
 
 ### タイプ
 
 Dialog 確認ボタンのみの警告を表示します。キャンセルや確認のメッセージ、あるいは直ちに対応が必要なユーザー ログインなどのコンテナーとして使用します。
 
-![](../images/dialog_alert.png)
-![](../images/dialog_standard.png)
-![](../images/dialog_custom.png)
+<img src="../images/dialog_alert.png" srcset="../images/dialog_alert@2x.png 2x" />
+<img src="../images/dialog_standard.png" srcset="../images/dialog_standard@2x.png 2x" />
+<img src="../images/dialog_custom.png" srcset="../images/dialog_custom@2x.png 2x" />
 
 ### スタイル設定
 
 Dialog は、さまざまなオーバーライドでタイトルやメッセージ、2 種類の [Button](button.md) タイプで個別にスタイル設定したボタンを制御することにより柔軟にスタイル設定できます。
 
-![](../images/dialog_styling.png)
+<img src="../images/dialog_styling.png" srcset="../images/dialog_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -33,7 +33,7 @@ Dialog は、さまざまなオーバーライドでタイトルやメッセー�
 
 | いい例                            | 悪い例                           |
 | ----------------------------- | ------------------------------- |
-| ![](../images/dialog_do1.png) | ![](../images/dialog_dont1.png) |
+| <img src="../images/dialog_do1.png" srcset="../images/dialog_do1@2x.png 2x" /> | <img src="../images/dialog_dont1.png" srcset="../images/dialog_dont1@2x.png 2x" /> |
 
 ## コードの生成
 

--- a/jp/components/grid-column-pinning.md
+++ b/jp/components/grid-column-pinning.md
@@ -11,7 +11,7 @@ Grid 列ピン固定は、ユーザーが列を右または左へスクロール
 
 ### Grid 列ピン固定デモ
 
-![](../images/grid_column_pinning_demo.png)
+<img src="../images/grid_column_pinning_demo.png" srcset="../images/grid_column_pinning_demo@2x.png 2x" />
 
 ### セルの右境界線
 

--- a/jp/components/grid-filter.md
+++ b/jp/components/grid-filter.md
@@ -10,21 +10,21 @@ Grid フィルター コンポーネントは、Grid 列でユーザーがフィ
 
 ### Grid フィルター デモ
 
-![](../images/grid_filter_demo.png)
+<img src="../images/grid_filter_demo.png" srcset="../images/grid_filter_demo@2x.png 2x" />
 
 ### フィルター状態
 
 ヘッダー セルの Grid フィルター状態は、フィルタリングのインタラクションで選択できる 3 つの状態があります。**インアクティブ**状態は列でフィルタリングを適用可能であることを示します。アクティブ状態はフィルタリング条件を定義できるダイアログが表示されています。フィルター済み状態は、ダイアログが非表示になった後にフィルターが適用された状態を示します。
 
-![](../images/grid_filter_state_inactive.png)
-![](../images/grid_filter_state_active.png)
-![](../images/grid_filter_state_filtered.png)
+<img src="../images/grid_filter_state_inactive.png" srcset="../images/grid_filter_state_inactive@2x.png 2x" />
+<img src="../images/grid_filter_state_active.png" srcset="../images/grid_filter_state_active@2x.png 2x" />
+<img src="../images/grid_filter_state_filtered.png" srcset="../images/grid_filter_state_filtered@2x.png 2x" />
 
 ### スタイル設定
 
 ヘッダー セルの Grid フィルター状態は、さまざまなオーバーライドでアイコンやアクティブな背景色などスタイル設定に柔軟性があります。Grid フィルター ダイアログは、さまざまなオーバーライドでダイアログの背景色などのスタイル設定に柔軟性があり、[Inputs](input.md) や [Flat Buttons](button.md) のスタイル設定も可能です。
 
-![](../images/grid_filter_styling.png)
+<img src="../images/grid_filter_styling.png" srcset="../images/grid_filter_styling@2x.png 2x" />
 
 ## その他のリソース
 

--- a/jp/components/grid-paging.md
+++ b/jp/components/grid-paging.md
@@ -12,13 +12,13 @@ Grid ページングは、[Ignite UI for Angular Grid ページング機能](htt
 
 ### Grid ページング デモ
 
-![](../images/grid_paging_demo.png)
+<img src="../images/grid_paging_demo.png" srcset="../images/grid_paging_demo@2x.png 2x" />
 
 ### スタイル設定
 
 Grid ページングは、さまざまなオーバーライドでラベルや背景色などのスタイル設定に柔軟性があり、ナビゲーションに使用する Icon Buttons のスタイル設定も可能です。
 
-![](../images/grid_paging_styling.png)
+<img src="../images/grid_paging_styling.png" srcset="../images/grid_paging_styling@2x.png 2x" />
 
 ## その他のリソース
 

--- a/jp/components/grid-summaries.md
+++ b/jp/components/grid-summaries.md
@@ -11,28 +11,28 @@ Grid 集計は、すべてのデータで算出した集計値を各 Grid 列に
 
 ### Grid 集計デモ
 
-![](../images/grid_summaries_demo.png)
+<img src="../images/grid_summaries_demo.png" srcset="../images/grid_summaries_demo@2x.png 2x" />
 
 ### 状態
 
 Grid 集計セルは、以下のインタラクティブな状態をサポートします。**アクティブ**は Label および Number の概要を示します。インアクティブは、グレー アウトされたラベルを示します。Number を非表示にします。unavailable は 1 つの列に他の列より集計が少ない場合にギャップを埋めます。
 
-![](../images/grid_cell_summary_active.png)
-![](../images/grid_cell_summary_inactive.png)
-![](../images/grid_cell_summary_unavailable.png)
+<img src="../images/grid_cell_summary_active.png" srcset="../images/grid_cell_summary_active@2x.png 2x" />
+<img src="../images/grid_cell_summary_inactive.png" srcset="../images/grid_cell_summary_inactive@2x.png 2x" />
+<img src="../images/grid_cell_summary_unavailable.png" srcset="../images/grid_cell_summary_unavailable@2x.png 2x" />
 
 ### タイプ
 
 Grid 集計セルには一般的なタイプのプリセットが 2 タイプあり、数値の **Number** と文字列の Text に対応する必要があります。
 
-![](../images/grid_cell_summary_number.png)
-![](../images/grid_cell_summary_text.png)
+<img src="../images/grid_cell_summary_number.png" srcset="../images/grid_cell_summary_number@2x.png 2x" />
+<img src="../images/grid_cell_summary_text.png" srcset="../images/grid_cell_summary_text@2x.png 2x" />
 
 ### スタイル設定
 
 Grid 集計セルは、さまざまなオーバーライドでラベル、数値テキスト色、セルの背景色を制御することにより柔軟にスタイル設定できます。
 
-![](../images/grid_summaries_styling.png)
+<img src="../images/grid_summaries_styling.png" srcset="../images/grid_summaries_styling@2x.png 2x" />
 
 ## その他のリソース
 

--- a/jp/components/grid.md
+++ b/jp/components/grid.md
@@ -11,7 +11,7 @@ Grid コンポーネントは大量の複雑なデータをタブ形式し、ユ
 
 ### Grid デモ
 
-![](../images/grid_demo.png)
+<img src="../images/grid_demo.png" srcset="../images/grid_demo@2x.png 2x" />
 
 ### シンボルからデタッチ
 
@@ -29,45 +29,45 @@ Grid は、基本的に表形式でデータを表示する列と行のリピー
 
 Grid は、異なるデータ可視化用に 3 タイプのセルがあります。Header Cell は、各列に 1 つでグリッドの一番上に表示され、特定の列のデータに関する説明をテキストで表示します。Body Cell は、データ レコードを表示するテーブルのビルドその他に使用されます。Summary Cell は、列[集計](grid-summaries.md)がカウント、最大、最小などの各ディメンションに表示される Grid の下のセクションを作成するために使用されます。
 
-![](../images/grid_cell_header.png)
-![](../images/grid_cell_body.png)
-![](../images/grid_cell_summary.png)
+<img src="../images/grid_cell_header.png" srcset="../images/grid_cell_header@2x.png 2x" />
+<img src="../images/grid_cell_body.png" srcset="../images/grid_cell_body@2x.png 2x" />
+<img src="../images/grid_cell_summary.png" srcset="../images/grid_cell_summary@2x.png 2x" />
 
 ### 項目 (ヘッダー セル)
 
 Grid Header Cell は、項目のオーバーライドで次のレイアウトの組み合わせをサポートします。ヘッダー テキストのみを表示する**アイコンはなく**、ヘッダー テキストとフィルター アイコンを表示するアイコン、ヘッダーテキストを表示するアイコン、フィルターアイコンと並べ替えアイコンがあります。
 
-![](../images/grid_cell_header_no-icon.png)
-![](../images/grid_cell_header_icon.png)
-![](../images/grid_cell_header_icons.png)
+<img src="../images/grid_cell_header_no-icon.png" srcset="../images/grid_cell_header_no-icon@2x.png 2x" />
+<img src="../images/grid_cell_header_icon.png" srcset="../images/grid_cell_header_icon@2x.png 2x" />
+<img src="../images/grid_cell_header_icons.png" srcset="../images/grid_cell_header_icons@2x.png 2x" />
 
 ### 状態 (本体セル)
 
 Grid Body Cell は、以下のインタラクティブな状態をサポートします。標準状態の **Rest**、セル選択モードで選択したセルの CellSelected、選択セルのある行の残りのセルの RowSelected。
 
-![](../images/grid_cell_body_rest.png)
-![](../images/grid_cell_body_cell-selected.png)
-![](../images/grid_cell_body_row-selected.png)
+<img src="../images/grid_cell_body_rest.png" srcset="../images/grid_cell_body_rest@2x.png 2x" />
+<img src="../images/grid_cell_body_cell-selected.png" srcset="../images/grid_cell_body_cell-selected@2x.png 2x" />
+<img src="../images/grid_cell_body_row-selected.png" srcset="../images/grid_cell_body_row-selected@2x.png 2x" />
 
 ### セル タイプ
 
 Grid Header Cell は、対応が必要な一般的なデータ型のプリセットが 3 つあります。数値のための **Number**、文字列の Text、最初の列の通常テンプレートとして使用される Checkbox、複数行の選択が可能にする最初の列のテンプレート。
 
-![](../images/grid_cell_header_number.png)
-![](../images/grid_cell_header_text.png)
-![](../images/grid_cell_header_checkbox.png)
+<img src="../images/grid_cell_header_number.png" srcset="../images/grid_cell_header_number@2x.png 2x" />
+<img src="../images/grid_cell_header_text.png" srcset="../images/grid_cell_header_text@2x.png 2x" />
+<img src="../images/grid_cell_header_checkbox.png" srcset="../images/grid_cell_header_checkbox@2x.png 2x" />
 
 Grid Body Cell は、Header Cell などの同じ一般的なデータ型プリセットを提供します。
 
-![](../images/grid_cell_body_number.png)
-![](../images/grid_cell_body_text.png)
-![](../images/grid_cell_body_checkbox.png)
+<img src="../images/grid_cell_body_number.png" srcset="../images/grid_cell_body_number@2x.png 2x" />
+<img src="../images/grid_cell_body_text.png" srcset="../images/grid_cell_body_text@2x.png 2x" />
+<img src="../images/grid_cell_body_checkbox.png" srcset="../images/grid_cell_body_checkbox@2x.png 2x" />
 
 ### スタイル設定
 
 Grid は、さまざま状態の各セル テキスト、アイコン、背景色のスタイル設定や水平および垂直の境界線の非表示など柔軟に変更できます。
 
-![](../images/grid_styling.png)
+<img src="../images/grid_styling.png" srcset="../images/grid_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -75,7 +75,7 @@ Grid の最も重要な点は、Header および Body Cells 内のデータの�
 
 | いい例                      | 悪い例                        |
 | --------------------------- | ----------------------------- |
-| ![](../images/grid_do1.png) | ![](../images/grid_dont1.png) |
+| <img src="../images/grid_do1.png" srcset="../images/grid_do1@2x.png 2x" /> | <img src="../images/grid_dont1.png" srcset="../images/grid_dont1@2x.png 2x" /> |
 
 ## その他のリソース
 

--- a/jp/components/hyperlink.md
+++ b/jp/components/hyperlink.md
@@ -11,19 +11,19 @@ Hyperlink コンポーネント シンボルは、利用規約やプライバシ
 
 ### Hyperlink デモ
 
-![](../images/hyperlink_demo.png)
+<img src="../images/hyperlink_demo.png" srcset="../images/hyperlink_demo@2x.png 2x" />
 
 ### サイズ
 
 Hyperlink には段落のテキストに合わせて 2 サイズ (16pt Body 1 と 14pt Body 2) あります。
 
-![](../images/hyperlink_sizes.png)
+<img src="../images/hyperlink_sizes.png" srcset="../images/hyperlink_sizes@2x.png 2x" />
 
 ### スタイル設定
 
 Hyperlink は、デフォルトの青色と他の色に変更してスタイル ライブラリでスタイル設定できます。
 
-![](../images/calendar_styling.png)
+<img src="../images/calendar_styling.png" srcset="../images/calendar_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -31,7 +31,7 @@ Hyperlink テキスト色には段落で目立つ色を選択します。同じ�
 
 | いい例                               | 悪い例                              |
 | -------------------------------- | ---------------------------------- |
-| ![](../images/hyperlink_do1.png) | ![](../images/hyperlink_dont1.png) |
+| <img src="../images/hyperlink_do1.png" srcset="../images/hyperlink_do1@2x.png 2x" /> | <img src="../images/hyperlink_dont1.png" srcset="../images/hyperlink_dont1@2x.png 2x" /> |
 
 ## コードの生成
 

--- a/jp/components/icon.md
+++ b/jp/components/icon.md
@@ -11,7 +11,7 @@ Icon コンポーネント シンボルは、製品に「いいね」などの�
 
 ### Icon デモ
 
-![](../images/icon_demo.png)
+<img src="../images/icon_demo.png" srcset="../images/icon_demo@2x.png 2x" />
 
 ### サイズ
 
@@ -22,13 +22,13 @@ Icon のサイズは 4 つあります。
 - Medium
 - Small
 
-![](../images/icon_sizes.png)
+<img src="../images/icon_sizes.png" srcset="../images/icon_sizes@2x.png 2x" />
 
 ### スタイル設定
 
 Icon は、さまざまなオーバーライドで選択可能なグラフィックや塗りつぶしの色を制御することにより柔軟にスタイル設定できます。
 
-![](../images/icon_styling.png)
+<img src="../images/icon_styling.png" srcset="../images/icon_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -36,7 +36,7 @@ Icon の色は、背景とのコントラストが高い色を選択し、同色
 
 | いい例                      | 悪い例                        |
 | --------------------------- | ----------------------------- |
-| ![](../images/icon_do1.png) | ![](../images/icon_dont1.png) |
+| <img src="../images/icon_do1.png" srcset="../images/icon_do1@2x.png 2x" /> | <img src="../images/icon_dont1.png" srcset="../images/icon_dont1@2x.png 2x" /> |
 
 ## コードの生成
 

--- a/jp/components/input.md
+++ b/jp/components/input.md
@@ -11,54 +11,54 @@ Input コンポーネント シンボルは、さまざまなコンテキスト�
 
 ### Input デモ
 
-![](../images/input_demo.png)
+<img src="../images/input_demo.png" srcset="../images/input_demo@2x.png 2x" />
 
 ### タイプ
 
 Input はヘルパー テキスト (あり/なし) で 4 つの異なるタイプから選択します。より軽い印象となる線スタイルまたは単色背景ではっきり認識される境界線スタイルなど。Boxed スタイルは、コンテンツを読みやすくするために Input をビビッドなイメージの上に配置したときに使用するのが最も適しています。
 
-![](../images/input_no-helper.png)
-![](../images/input_helper.png)
+<img src="../images/input_no-helper.png" srcset="../images/input_no-helper@2x.png 2x" />
+<img src="../images/input_helper.png" srcset="../images/input_helper@2x.png 2x" />
 
-![](../images/input_line.png)
+<img src="../images/input_line.png" srcset="../images/input_line@2x.png 2x" />
 `line`
-![](../images/input_box.png)
+<img src="../images/input_box.png" srcset="../images/input_box@2x.png 2x" />
 `box`
-![](../images/input_border.png)
+<img src="../images/input_border.png" srcset="../images/input_border@2x.png 2x" />
 `border`
-![](../images/input_search.png)
+<img src="../images/input_search.png" srcset="../images/input_search@2x.png 2x" />
 `search`
 
 ### バリアント
 
 Input は、明暗バリアントで分かりやすく、背景に明暗のコントラストを付けてスタイル設定できます。
 
-![](../images/input_dark.png)
-![](../images/input_light.png)
+<img src="../images/input_dark.png" srcset="../images/input_dark@2x.png 2x" />
+<img src="../images/input_light.png" srcset="../images/input_light@2x.png 2x" />
 
 ### 状態
 
 ユーザーが Input とインタラクティブに操作する際にさまざまな状態を経由します。コンテンツの代わりにプレースホルダーがある**アイドル**状態、ユーザーが入力中のフォーカス状態、ユーザーがコンテンツの追加を完了して次に進むときの塗りつぶし状態、入力がインタラクションをサポートしない無効状態。柔軟性が向上したことにより、Hi-Fi プロトタイプへシームレスにフローする動的なインタラクション デザインの作成が可能です。
 
-![](../images/input_focused.png)
+<img src="../images/input_focused.png" srcset="../images/input_focused@2x.png 2x" />
 `focused`
-![](../images/input_filled.png)
+<img src="../images/input_filled.png" srcset="../images/input_filled@2x.png 2x" />
 `filled`
-![](../images/input_disabled.png)
+<img src="../images/input_disabled.png" srcset="../images/input_disabled@2x.png 2x" />
 `disabled`
 
 経験豊富なデザイナーは、ユーザー入力を制限して無効な状態を防止するために、検証スタイルを使用します。検証スタイルは、Input で成功、警告、エラーを表示する洗練されたデザインを提供します。
 
-![](../images/input_success.png)
-![](../images/input_warning.png)
-![](../images/input_error.png)
+<img src="../images/input_success.png" srcset="../images/input_success@2x.png 2x" />
+<img src="../images/input_warning.png" srcset="../images/input_warning@2x.png 2x" />
+<img src="../images/input_error.png" srcset="../images/input_error@2x.png 2x" />
 
 ### レイアウト
 
 Input には特定の場合に入力 (@email.com サフィックス) を軽減するテキスト文字列のプレフィックス/サフィックスやアイコンをサポートします。これによりキーストロークを減らし、予期されるコンテンツを明確にすることができます。カレンダーのプレフィックスでは、Input が日付や時間のコンテンツとして適しているかを示すことができます。
 
-![](../images/input_prefix.png)
-![](../images/input_suffix.png)
+<img src="../images/input_prefix.png" srcset="../images/input_prefix@2x.png 2x" />
+<img src="../images/input_suffix.png" srcset="../images/input_suffix@2x.png 2x" />
 
 > [!Note]
 > ↳ Layout
@@ -73,14 +73,14 @@ Input には特定の場合に入力 (@email.com サフィックス) を軽減�
 
 日付および時間選択のためにカスタマイズされた Input の 2 種類です。その他の Input コンポーネントと構造が統一されますが、レイアウトはそれぞれの状態に固定されます。プレフィックス位置に表示されるアイコンはマテリアル アイコンの `calendar-today` および `access-time` に設定され、オーバーライド パネルに変更できません。
 
-![](../images/input_calendar.png)
-![](../images/input_time-picker.png)
+<img src="../images/input_calendar.png" srcset="../images/input_calendar@2x.png 2x" />
+<img src="../images/input_time-picker.png" srcset="../images/input_time-picker@2x.png 2x" />
 
 ### スタイル設定
 
 Input は、Styling ライブラリのテーマでプライマリ、成功、警告、エラーの色を変更できます。
 
-![](../images/input_styling.png)
+<img src="../images/input_styling.png" srcset="../images/input_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -88,8 +88,8 @@ Input のボックス タイプを使用して画像上にフォームを配置�
 
 | いい例                       | 悪い例                         |
 | ---------------------------- | ------------------------------ |
-| ![](../images/input_do1.png) | ![](../images/input_dont1.png) |
-| ![](../images/input_do2.png) | ![](../images/input_dont2.png) |
+| <img src="../images/input_do1.png" srcset="../images/input_do1@2x.png 2x" /> | <img src="../images/input_dont1.png" srcset="../images/input_dont1@2x.png 2x" /> |
+| <img src="../images/input_do2.png" srcset="../images/input_do2@2x.png 2x" /> | <img src="../images/input_dont2.png" srcset="../images/input_dont2@2x.png 2x" /> |
 
 ## コードの生成
  

--- a/jp/components/list-custom.md
+++ b/jp/components/list-custom.md
@@ -11,14 +11,14 @@ Custom List Item シンボルは、通常の List Item と同じタイプの情�
 
 ### Custom List Item デモ
 
-![](../images/list_item_custom_demo.png)
+<img src="../images/list_item_custom_demo.png" srcset="../images/list_item_custom_demo@2x.png 2x" />
 
 ### 状態
 
 Custom List Item はインアクティブ状態 (標準状態のインアクティブと選択状態のアクティブ) をサポートします。
 
-![](../images/list_item_custom_inactive.png)
-![](../images/list_item_custom_active.png)
+<img src="../images/list_item_custom_inactive.png" srcset="../images/list_item_custom_inactive@2x.png 2x" />
+<img src="../images/list_item_custom_active.png" srcset="../images/list_item_custom_active@2x.png 2x" />
 
 ### シンボルからデタッチ
 
@@ -35,31 +35,31 @@ List Item レイアウトをカスタマイズするには、`List/Custom/Item` 
 
 Custom List Item は、Secondary Actions のオーバーライドおよびテキスト、アイコン、ボタン色の制御の一般的な List Item 同様にスタイル設定に高い柔軟性があります。各 List Item 同様にオーバーライドで Item 背景色を指定できます。
 
-![](../images/list_item_custom_styling.png)
+<img src="../images/list_item_custom_styling.png" srcset="../images/list_item_custom_styling@2x.png 2x" />
 
 #### レイアウト
 
 以下は、上記の製品 List Item の複雑なレイアウトを 3 つのシンプルなステップで作成する方法です。空 Artboard の Custom List Item をドラッグし、`シンボルからデタッチ`を選択して、状態の背景色を変更する基本スタイルを適用します。開始ポイントにも同様に適用します。
 
-![](../images/list_item_custom_layout0.png)
+<img src="../images/list_item_custom_layout0.png" srcset="../images/list_item_custom_layout0@2x.png 2x" />
 
 1.  Primary Action Group の Header を再利用しますが右半分のみに合わせてサイズ変更し、Title と Subtitile Text の文字列を更新します。Secondary Action Group で Raised Button 配置を右下近くに追加します。テキストの更新して新しい値に合わせてサイズ変更します。ターゲット カスタム レイアウトに Icons は必要ないため、最後にデフォルト Secondary Action を削除します。
 
-  ![](../images/list_item_custom_layout1.png)
+  <img src="../images/list_item_custom_layout1.png" srcset="../images/list_item_custom_layout1@2x.png 2x" />
 
 2.  次に List/Custom/Blocks/Image Content を Primary Action Group に挿入し、同じグループ内で一番上に Badge を追加します。Item サイズに基づいて画像をサイズ変更し、コンテンツを選択します。Badge を変更して Value Text を更新した後に Border と Elevation を非表示にし、これと同様のものを取得します。
 
-  ![](../images/list_item_custom_layout2.png)
+  <img src="../images/list_item_custom_layout2.png" srcset="../images/list_item_custom_layout2@2x.png 2x" />
 
 3.  前のステップでは Text/Title 要素を Primary Action Group に追加します。H3 で製品価格を表示し、その右に H6 で追加のテキストを表示します。Header と Raised Button 間の空スペースに配置後、ターゲット レイアウトが完了した Raised Button の最終的な配置を調整できます。
 
-  ![](../images/list_item_custom_layout3.png)
+  <img src="../images/list_item_custom_layout3.png" srcset="../images/list_item_custom_layout3@2x.png 2x" />
 
 #### 追加のスタイル
 
 List Item レイアウトでは、挿入されている要素に基づいてさまざまなスタイルを追加することが可能になります。たとえば、テキストの色を設定して強調したり、Badge 背景や Raised Button 背景の色を変更したりできます。
 
-![](../images/list_item_custom_layout_styled.png)
+<img src="../images/list_item_custom_layout_styled.png" srcset="../images/list_item_custom_layout_styled@2x.png 2x" />
 
 ## その他のリソース
 

--- a/jp/components/list.md
+++ b/jp/components/list.md
@@ -11,7 +11,7 @@ List コンポーネント シンボルは、ユーザーのブラウジング�
 
 ### List デモ
 
-![](../images/list_demo.png)
+<img src="../images/list_demo.png" srcset="../images/list_demo@2x.png 2x" />
 
 ### シンボルからデタッチ
 
@@ -32,23 +32,23 @@ List は、本来インデックス付きの垂直コレクションとしてデ
 
 List 項目には 3 つのプリセット タイプがあります。グループの見出しを定義する Header、1 行のテキストを含む短い項目の One-line、プライマリおよびセカンダリ テキストをサポートするより高さのある項目の Two-line。
 
-![](../images/list_item_header.png)
-![](../images/list_item_one-line.png)
-![](../images/list_item_two-line.png)
+<img src="../images/list_item_header.png" srcset="../images/list_item_header@2x.png 2x" />
+<img src="../images/list_item_one-line.png" srcset="../images/list_item_one-line@2x.png 2x" />
+<img src="../images/list_item_two-line.png" srcset="../images/list_item_two-line@2x.png 2x" />
 
 ### List 項目の状態
 
 One-line および Two-line List 項目は**インアクティブ**状態 (標準状態のインアクティブと選択状態のアクティブ) をサポートします。Header List 項目は選択できないため、そのような States はサポートしません。
 
-![](../images/list_item_inactive.png)
-![](../images/list_item_active.png)
+<img src="../images/list_item_inactive.png" srcset="../images/list_item_inactive@2x.png 2x" />
+<img src="../images/list_item_active.png" srcset="../images/list_item_active@2x.png 2x" />
 
 ### List 項目の領域
 
 List 項目は、2 つの異なる領域があります。Primary Action は、非インタラクティブなコンテンツで Avatar やテキストなどをレイアウトします。Secondary Action には List 項目に関連するクイック アクションがあります。Primary と Secondary 操作は有効なリスト項目テンプレートを形成し、常に List 項目全体で使用されます。
 
-![](../images/list_item_primary.png)
-![](../images/list_item_secondary.png)
+<img src="../images/list_item_primary.png" srcset="../images/list_item_primary@2x.png 2x" />
+<img src="../images/list_item_secondary.png" srcset="../images/list_item_secondary@2x.png 2x" />
 
 ### List 項目プライマリ アクション
 
@@ -56,16 +56,16 @@ List 項目は、2 つの異なる領域があります。Primary Action は、�
 
 |                              |                                        |                    |
 | ---------------------------- | -------------------------------------- | ------------------ |
-| Avatar + Description + Label | ![](../images/list_item_primary.png)   |                    |
-| Avatar + Label               | ![](../images/list_item_primary2.png)  |                    |
-| Avatar + Label + Description | ![](../images/list_item_primary3.png)  |                    |
-| Description + Label          | ![](../images/list_item_primary4.png)  |                    |
-| Icon + Description + Label   | ![](../images/list_item_primary5.png)  |                    |
-| Icon + Label                 | ![](../images/list_item_primary6.png)  |                    |
-| Icon + Label + Description   | ![](../images/list_item_primary7.png)  |                    |
-| Label                        | ![](../images/list_item_primary8.png)  |                    |
-| Label + Description          | ![](../images/list_item_primary9.png)  |                    |
-| Label + Progress             | ![](../images/list_item_primary10.png) | Primary Action の Progress に基本テキストを設定できないため、Text Style が None に設定され、この設定は変更できません。 |
+| Avatar + Description + Label | <img src="../images/list_item_primary.png" srcset="../images/list_item_primary@2x.png 2x" />   |                    |
+| Avatar + Label               | <img src="../images/list_item_primary2.png" srcset="../images/list_item_primary2@2x.png 2x" />  |                    |
+| Avatar + Label + Description | <img src="../images/list_item_primary3.png" srcset="../images/list_item_primary3@2x.png 2x" />  |                    |
+| Description + Label          | <img src="../images/list_item_primary4.png" srcset="../images/list_item_primary4@2x.png 2x" />  |                    |
+| Icon + Description + Label   | <img src="../images/list_item_primary5.png" srcset="../images/list_item_primary5@2x.png 2x" />  |                    |
+| Icon + Label                 | <img src="../images/list_item_primary6.png" srcset="../images/list_item_primary6@2x.png 2x" />  |                    |
+| Icon + Label + Description   | <img src="../images/list_item_primary7.png" srcset="../images/list_item_primary7@2x.png 2x" />  |                    |
+| Label                        | <img src="../images/list_item_primary8.png" srcset="../images/list_item_primary8@2x.png 2x" />  |                    |
+| Label + Description          | <img src="../images/list_item_primary9.png" srcset="../images/list_item_primary9@2x.png 2x" />  |                    |
+| Label + Progress             | <img src="../images/list_item_primary10.png" srcset="../images/list_item_primary10@2x.png 2x" /> | Primary Action の Progress に基本テキストを設定できないため、Text Style が None に設定され、この設定は変更できません。 |
 
 ### List 項目セコンダリ アクション
 
@@ -73,19 +73,19 @@ List 項目は、2 つの異なる領域があります。Primary Action は、�
 
 |                  |                                         |                    |
 | ---------------- | --------------------------------------- | ------------------ |
-| Badge            | ![](../images/list_item_secondary.png)  |                    |
-| Checkbox         | ![](../images/list_item_secondary2.png) | Secondary Action の Checkbox にラベルを設定できないため、Label Style が None に設定され、この設定は変更できません。 |
-| Icons            | ![](../images/list_item_secondary3.png) |                    |
-| Text             | ![](../images/list_item_secondary4.png) |                    |
-| Text + Icons     | ![](../images/list_item_secondary5.png) |                    |
-| Toggle           | ![](../images/list_item_secondary6.png) | Secondary Action の Switch にラベルを設定できないため、Label Style が None に設定され、この設定は変更できません。 |
-| Two-line Numbers | ![](../images/list_item_secondary7.png) |                    |
+| Badge            | <img src="../images/list_item_secondary.png" srcset="../images/list_item_secondary@2x.png 2x" />  |                    |
+| Checkbox         | <img src="../images/list_item_secondary2.png" srcset="../images/list_item_secondary2@2x.png 2x" /> | Secondary Action の Checkbox にラベルを設定できないため、Label Style が None に設定され、この設定は変更できません。 |
+| Icons            | <img src="../images/list_item_secondary3.png" srcset="../images/list_item_secondary3@2x.png 2x" /> |                    |
+| Text             | <img src="../images/list_item_secondary4.png" srcset="../images/list_item_secondary4@2x.png 2x" /> |                    |
+| Text + Icons     | <img src="../images/list_item_secondary5.png" srcset="../images/list_item_secondary5@2x.png 2x" /> |                    |
+| Toggle           | <img src="../images/list_item_secondary6.png" srcset="../images/list_item_secondary6@2x.png 2x" /> | Secondary Action の Switch にラベルを設定できないため、Label Style が None に設定され、この設定は変更できません。 |
+| Two-line Numbers | <img src="../images/list_item_secondary7.png" srcset="../images/list_item_secondary7@2x.png 2x" /> |                    |
 
 ### スタイル設定
 
 List は、さまざまなオーバーライドで背景色、アイコン、テキストなどの List 項目に使用するさまざまな要素、Avatar、Badge、Chechbox、Icon、Progress、Switch などのコンポーネントなどスタイル設定に柔軟性があります。
 
-![](../images/list_styling.png)
+<img src="../images/list_styling.png" srcset="../images/list_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -93,9 +93,9 @@ List および List 項目には固有のデザインがありますが、List �
 
 | いい例                      | 悪い例                        |
 | --------------------------- | ----------------------------- |
-| ![](../images/list_do1.png) | ![](../images/list_dont1.png) |
-| ![](../images/list_do2.png) | ![](../images/list_dont2.png) |
-| ![](../images/list_do3.png) | ![](../images/list_dont3.png) |
+| <img src="../images/list_do1.png" srcset="../images/list_do1@2x.png 2x" /> | <img src="../images/list_dont1.png" srcset="../images/list_dont1@2x.png 2x" /> |
+| <img src="../images/list_do2.png" srcset="../images/list_do2@2x.png 2x" /> | <img src="../images/list_dont2.png" srcset="../images/list_dont2@2x.png 2x" /> |
+| <img src="../images/list_do3.png" srcset="../images/list_do3@2x.png 2x" /> | <img src="../images/list_dont3.png" srcset="../images/list_dont3@2x.png 2x" /> |
 
 ## その他のリソース
 

--- a/jp/components/nav-drawer.md
+++ b/jp/components/nav-drawer.md
@@ -11,20 +11,20 @@ Navigation Drawer コンポーネント シンボルは、複数の項目と画�
 
 ### Navigation Drawer デモ
 
-![](../images/nav-drawer_demo.png)
+<img src="../images/nav-drawer_demo.png" srcset="../images/nav-drawer_demo@2x.png 2x" />
 
 ### スタイル
 
 Navigation Drawer は、各項目にアイコンとラベルを含む**デフォルト** スタイルとアイコンのみ含むミニ スタイルがあります。デザインにある項目/ビューが 5 つ以下の場合、Navigation Drawer または [Bottom Navigation](bottom-nav.md) が適しています。
 
-![](../images/nav-drawer_default.png)
-![](../images/nav-drawer_mini.png)
+<img src="../images/nav-drawer_default.png" srcset="../images/nav-drawer_default@2x.png 2x" />
+<img src="../images/nav-drawer_mini.png" srcset="../images/nav-drawer_mini@2x.png 2x" />
 
 ### スタイル設定
 
 Navigation Drawer には、ラベルやアイコンの色の変更、アクティブ/インアクティブな背景の色の変更など基本的なスタイル設定機能があります。
 
-![](../images/nav-drawer_styling.png)
+<img src="../images/nav-drawer_styling.png" srcset="../images/nav-drawer_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -32,9 +32,9 @@ Navigation Drawer は、アプリの主要ナビゲーションに使用する�
 
 | いい例                                | 悪い例                               |
 | --------------------------------- | ----------------------------------- |
-| ![](../images/nav-drawer_do1.png) | ![](../images/nav-drawer_dont1.png) |
-| ![](../images/nav-drawer_do2.png) | ![](../images/nav-drawer_dont2.png) |
-| ![](../images/nav-drawer_do3.png) | ![](../images/nav-drawer_dont3.png) |
+| <img src="../images/nav-drawer_do1.png" srcset="../images/nav-drawer_do1@2x.png 2x" /> | <img src="../images/nav-drawer_dont1.png" srcset="../images/nav-drawer_dont1@2x.png 2x" /> |
+| <img src="../images/nav-drawer_do2.png" srcset="../images/nav-drawer_do2@2x.png 2x" /> | <img src="../images/nav-drawer_dont2.png" srcset="../images/nav-drawer_dont2@2x.png 2x" /> |
+| <img src="../images/nav-drawer_do3.png" srcset="../images/nav-drawer_do3@2x.png 2x" /> | <img src="../images/nav-drawer_dont3.png" srcset="../images/nav-drawer_dont3@2x.png 2x" /> |
 
 ## その他のリソース
 

--- a/jp/components/navbar.md
+++ b/jp/components/navbar.md
@@ -11,30 +11,30 @@ Navbar コンポーネント シンボルは、アプリケーションでユー
 
 ### Navbar デモ
 
-![](../images/navbar_demo.png)
+<img src="../images/navbar_demo.png" srcset="../images/navbar_demo@2x.png 2x" />
 
 ### タイプ
 
 Navbar は、3 つのレイアウト構成があり、**アイコン アクションとタイトル**、テキスト アクションとタイトル、タイトルのみで定義されます。
 
-![](../images/navbar_lefticon.png)
-![](../images/navbar_lefttext.png)
-![](../images/navbar_noleft.png)
+<img src="../images/navbar_lefticon.png" srcset="../images/navbar_lefticon@2x.png 2x" />
+<img src="../images/navbar_lefttext.png" srcset="../images/navbar_lefttext@2x.png 2x" />
+<img src="../images/navbar_noleft.png" srcset="../images/navbar_noleft@2x.png 2x" />
 
 ### アクション アイコン
 
 各 Navbar は、画面右端から左へ描画されるシンプルなイベントをトリガーする操作アイコンを 4 アイコンまでサポートします。
 
-![](../images/navbar_icon1.png)
-![](../images/navbar_icon2.png)
-![](../images/navbar_icon3.png)
-![](../images/navbar_icon4.png)
+<img src="../images/navbar_icon1.png" srcset="../images/navbar_icon1@2x.png 2x" />
+<img src="../images/navbar_icon2.png" srcset="../images/navbar_icon2@2x.png 2x" />
+<img src="../images/navbar_icon3.png" srcset="../images/navbar_icon3@2x.png 2x" />
+<img src="../images/navbar_icon4.png" srcset="../images/navbar_icon4@2x.png 2x" />
 
 ### スタイル設定
 
 Navbar には、タイトル、アイコン、背景色を変更する基本的なスタイル設定機能があります。
 
-![](../images/navbar_styling.png)
+<img src="../images/navbar_styling.png" srcset="../images/navbar_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -42,8 +42,8 @@ Navbar 操作は、タイトルと重ならないようにシンプル メニュ
 
 | いい例                            | 悪い例                           |
 | ----------------------------- | ------------------------------- |
-| ![](../images/navbar_do1.png) | ![](../images/navbar_dont1.png) |
-| ![](../images/navbar_do2.png) | ![](../images/navbar_dont2.png) |
+| <img src="../images/navbar_do1.png" srcset="../images/navbar_do1@2x.png 2x" /> | <img src="../images/navbar_dont1.png" srcset="../images/navbar_dont1@2x.png 2x" /> |
+| <img src="../images/navbar_do2.png" srcset="../images/navbar_do2@2x.png 2x" /> | <img src="../images/navbar_dont2.png" srcset="../images/navbar_dont2@2x.png 2x" /> |
 
 ## その他のリソース
 

--- a/jp/components/progress.md
+++ b/jp/components/progress.md
@@ -11,14 +11,14 @@ Progress コンポーネント シンボルは、タスクの進行状況につ�
 
 ### Progress デモ
 
-![](../images/progress_demo.png)
+<img src="../images/progress_demo.png" srcset="../images/progress_demo@2x.png 2x" />
 
 ### タイプ
 
 Progress は、さまざまなユースケースやレイアウト要件に対応するための 2 つのレイアウト タイプ (Circular Bar および Linear Bar) をサポートします。
 
-![](../images/progress_circular.png)
-![](../images/progress_linear.png)
+<img src="../images/progress_circular.png" srcset="../images/progress_circular@2x.png 2x" />
+<img src="../images/progress_linear.png" srcset="../images/progress_linear@2x.png 2x" />
 
 ### 状態
 
@@ -30,19 +30,19 @@ Progress は、以下のプリセット カラーの組み合わせの 1 つを�
 - error: `error` テーマ カラーを使用して進行状況を表示
 - info: `info` テーマ カラーを使用して進行状況を表示
 
-![](../images/progress_default.png)
-![](../images/progress_success.png)
-![](../images/progress_warn.png)
-![](../images/progress_error.png)
-![](../images/progress_info.png)
+<img src="../images/progress_default.png" srcset="../images/progress_default@2x.png 2x" />
+<img src="../images/progress_success.png" srcset="../images/progress_success@2x.png 2x" />
+<img src="../images/progress_warn.png" srcset="../images/progress_warn@2x.png 2x" />
+<img src="../images/progress_error.png" srcset="../images/progress_error@2x.png 2x" />
+<img src="../images/progress_info.png" srcset="../images/progress_info@2x.png 2x" />
 
 ### スタイル設定
 
 Progress は、さまざまなオーバーライドでテキスト、ストリップ、塗りつぶし、トラックの色を制御することにより柔軟にスタイル設定できます。
 
-![](../images/progress_striped.png)
-![](../images/progress_clear.png)
-![](../images/progress_twocolor.png)
+<img src="../images/progress_striped.png" srcset="../images/progress_striped@2x.png 2x" />
+<img src="../images/progress_clear.png" srcset="../images/progress_clear@2x.png 2x" />
+<img src="../images/progress_twocolor.png" srcset="../images/progress_twocolor@2x.png 2x" />
 
 ## 使用方法
 
@@ -50,8 +50,8 @@ Circular Bar は常にテキスト ラベルの実際の値を使用し、Linear
 
 | いい例                              | 悪い例                             |
 | ------------------------------- | --------------------------------- |
-| ![](../images/progress_do1.png) | ![](../images/progress_dont1.png) |
-| ![](../images/progress_do2.png) | ![](../images/progress_dont2.png) |
+| <img src="../images/progress_do1.png" srcset="../images/progress_do1@2x.png 2x" /> | <img src="../images/progress_dont1.png" srcset="../images/progress_dont1@2x.png 2x" /> |
+| <img src="../images/progress_do2.png" srcset="../images/progress_do2@2x.png 2x" /> | <img src="../images/progress_dont2.png" srcset="../images/progress_dont2@2x.png 2x" /> |
 
 ## コードの生成
 

--- a/jp/components/radio-group.md
+++ b/jp/components/radio-group.md
@@ -11,26 +11,26 @@ Radio Group コンポーネント シンボルは、グループ項目で排他�
 
 ### Radio Group デモ
 
-![](../images/radiogroup_demo.png)
+<img src="../images/radiogroup_demo.png" srcset="../images/radiogroup_demo@2x.png 2x" />
 
 ### テーマ
 
 Radio Group は、明暗バリアントでわかりやすく、背景に明暗のコントラストを付けてスタイル設定できます。すべての Radios を同じテーマに設定してださい。
 
-![](../images/radiogroup_dark.png)
-![](../images/radiogroup_light.png)
+<img src="../images/radiogroup_dark.png" srcset="../images/radiogroup_dark@2x.png 2x" />
+<img src="../images/radiogroup_light.png" srcset="../images/radiogroup_light@2x.png 2x" />
 
 ### 状態
 
 グループの各 Radio は、**オン**とオフ、そして追加のバリアントとしてインタラクション無効の状態があります。
 
-![](../images/radiogroup_states.png)
+<img src="../images/radiogroup_states.png" srcset="../images/radiogroup_states@2x.png 2x" />
 
 ### スタイル設定
 
 Radio Group は、さまざまなオーバーライドで各項目のラベル スタイルや色を制御することにより柔軟にスタイル設定できます。
 
-![](../images/radiogroup_styling.png)
+<img src="../images/radiogroup_styling.png" srcset="../images/radiogroup_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -38,8 +38,8 @@ Radio Group を追加項目で拡張する場合は、単一列で左寄せに�
 
 | いい例                                | 悪い例                               |
 | --------------------------------- | ----------------------------------- |
-| ![](../images/radiogroup_do1.png) | ![](../images/radiogroup_dont1.png) |
-| ![](../images/radiogroup_do2.png) | ![](../images/radiogroup_dont2.png) |
+| <img src="../images/radiogroup_do1.png" srcset="../images/radiogroup_do1@2x.png 2x" /> | <img src="../images/radiogroup_dont1.png" srcset="../images/radiogroup_dont1@2x.png 2x" /> |
+| <img src="../images/radiogroup_do2.png" srcset="../images/radiogroup_do2@2x.png 2x" /> | <img src="../images/radiogroup_dont2.png" srcset="../images/radiogroup_dont2@2x.png 2x" /> |
 
 ## コードの生成
 

--- a/jp/components/slider.md
+++ b/jp/components/slider.md
@@ -11,34 +11,34 @@ Slider コンポーネント シンボルは、単一値の選択や両値の最
 
 ### Slider デモ
 
-![](../images/slider_demo.png)
+<img src="../images/slider_demo.png" srcset="../images/slider_demo@2x.png 2x" />
 
 ### タイプ
 
 Slider は、単一値の選択につまみと範囲を指定するための 2 つのつまみを提供します。
 
-![](../images/slider_one-thumb.png)
-![](../images/slider_two-thumb.png)
+<img src="../images/slider_one-thumb.png" srcset="../images/slider_one-thumb@2x.png 2x" />
+<img src="../images/slider_two-thumb.png" srcset="../images/slider_two-thumb@2x.png 2x" />
 
 ### テーマ
 
 Slider は、ダーク/ライト系のテーマで分かりやすく、背景に明暗のコントラストを付けてスタイル設定できます。
 
-![](../images/slider_dark.png)
-![](../images/slider_light.png)
+<img src="../images/slider_dark.png" srcset="../images/slider_dark@2x.png 2x" />
+<img src="../images/slider_light.png" srcset="../images/slider_light@2x.png 2x" />
 
 ### 状態
 
 Slider は、値の変更が可能かどうかを設定する**有効**/無効の状態をサポートします。
 
-![](../images/slider_enabled.png)
-![](../images/slider_disabled.png)
+<img src="../images/slider_enabled.png" srcset="../images/slider_enabled@2x.png 2x" />
+<img src="../images/slider_disabled.png" srcset="../images/slider_disabled@2x.png 2x" />
 
 ### スタイル設定
 
 Slider は、さまざまなオーバーライドでラベル背景、つまみ、トラック、ベース トラックの色を制御することにより柔軟にスタイル設定できます。
 
-![](../images/slider_styling.png)
+<img src="../images/slider_styling.png" srcset="../images/slider_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -46,8 +46,8 @@ Slider のトラック カラーは常にトラック ベース カラーより�
 
 | いい例                            | 悪い例                           |
 | ----------------------------- | ------------------------------- |
-| ![](../images/slider_do1.png) | ![](../images/slider_dont1.png) |
-| ![](../images/slider_do2.png) | ![](../images/slider_dont2.png) |
+| <img src="../images/slider_do1.png" srcset="../images/slider_do1@2x.png 2x" /> | <img src="../images/slider_dont1.png" srcset="../images/slider_dont1@2x.png 2x" /> |
+| <img src="../images/slider_do2.png" srcset="../images/slider_do2@2x.png 2x" /> | <img src="../images/slider_dont2.png" srcset="../images/slider_dont2@2x.png 2x" /> |
 
 ## コードの生成
  

--- a/jp/components/snackbar.md
+++ b/jp/components/snackbar.md
@@ -11,13 +11,13 @@ Snackbar コンポーネント シンボルは、短い通知の表示やリス�
 
 ### Snackbar デモ
 
-![](../images/snackbar_demo.png)
+<img src="../images/snackbar_demo.png" srcset="../images/snackbar_demo@2x.png 2x" />
 
 ### スタイル設定
 
 Snackbar は、スタイル設定に制限があり操作ボタンのテキスト色のみ変更できます。
 
-![](../images/snackbar_styling.png)
+<img src="../images/snackbar_styling.png" srcset="../images/snackbar_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -25,9 +25,9 @@ Snackbar は、その他のコンテンツの一番上に表示されるため�
 
 | いい例                              | 悪い例                             |
 | ------------------------------- | --------------------------------- |
-| ![](../images/snackbar_do1.png) | ![](../images/snackbar_dont1.png) |
-| ![](../images/snackbar_do2.png) | ![](../images/snackbar_dont2.png) |
-| ![](../images/snackbar_do3.png) | ![](../images/snackbar_dont3.png) |
+| <img src="../images/snackbar_do1.png" srcset="../images/snackbar_do1@2x.png 2x" /> | <img src="../images/snackbar_dont1.png" srcset="../images/snackbar_dont1@2x.png 2x" /> |
+| <img src="../images/snackbar_do2.png" srcset="../images/snackbar_do2@2x.png 2x" /> | <img src="../images/snackbar_dont2.png" srcset="../images/snackbar_dont2@2x.png 2x" /> |
+| <img src="../images/snackbar_do3.png" srcset="../images/snackbar_do3@2x.png 2x" /> | <img src="../images/snackbar_dont3.png" srcset="../images/snackbar_dont3@2x.png 2x" /> |
 
 ## コードの生成
 

--- a/jp/components/switch.md
+++ b/jp/components/switch.md
@@ -11,36 +11,36 @@ Switch コンポーネント シンボルは、ユーザーが設定一覧でオ
 
 ### Switch デモ
 
-![](../images/switch_demo.png)
+<img src="../images/switch_demo.png" srcset="../images/switch_demo@2x.png 2x" />
 
 ### テーマ
 
 Switch は、明暗バリアントで分かりやすく、背景に明暗のコントラストを付けてスタイル設定できます。
 
-![](../images/switch_dark.png)
-![](../images/switch_light.png)
+<img src="../images/switch_dark.png" srcset="../images/switch_dark@2x.png 2x" />
+<img src="../images/switch_light.png" srcset="../images/switch_light@2x.png 2x" />
 
 ### ラベルの使用
 
 Switch はラベルなしで使用できます。ラベルを非表示にするためにテキスト値を空/スペース文字にしてコンポーネントの幅を小さくします(38px など)。
 
-![](../images/switch_label.png)
-![](../images/switch_no_label.png)
+<img src="../images/switch_label.png" srcset="../images/switch_label@2x.png 2x" />
+<img src="../images/switch_no_label.png" srcset="../images/switch_no_label@2x.png 2x" />
 
 ### 状態
 
 Switch は、オン/オフと選択状態があり、追加のバリアントとしてインタラクション無効の状態があります。
 
-![](../images/switch_on.png)
-![](../images/switch_on_disabled.png)
-![](../images/switch_off.png)
-![](../images/switch_off_disabled.png)
+<img src="../images/switch_on.png" srcset="../images/switch_on@2x.png 2x" />
+<img src="../images/switch_on_disabled.png" srcset="../images/switch_on_disabled@2x.png 2x" />
+<img src="../images/switch_off.png" srcset="../images/switch_off@2x.png 2x" />
+<img src="../images/switch_off_disabled.png" srcset="../images/switch_off_disabled@2x.png 2x" />
 
 ### スタイル設定
 
 Switch は、つまみとトラック色を制御でき柔軟なスタイル設定が可能です。固定アルファ値がトラックに適用されて半透明になります。
 
-![](../images/switch_styling.png)
+<img src="../images/switch_styling.png" srcset="../images/switch_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -48,9 +48,9 @@ Switch は、設定リストで状態を制御するオプションを説明す�
 
 | いい例                            | 悪い例                           |
 | ----------------------------- | ------------------------------- |
-| ![](../images/switch_do1.png) | ![](../images/switch_dont1.png) |
-| ![](../images/switch_do2.png) | ![](../images/switch_dont2.png) |
-| ![](../images/switch_do3.png) | ![](../images/switch_dont3.png) |
+| <img src="../images/switch_do1.png" srcset="../images/switch_do1@2x.png 2x" /> | <img src="../images/switch_dont1.png" srcset="../images/switch_dont1@2x.png 2x" /> |
+| <img src="../images/switch_do2.png" srcset="../images/switch_do2@2x.png 2x" /> | <img src="../images/switch_dont2.png" srcset="../images/switch_dont2@2x.png 2x" /> |
+| <img src="../images/switch_do3.png" srcset="../images/switch_do3@2x.png 2x" /> | <img src="../images/switch_dont3.png" srcset="../images/switch_dont3@2x.png 2x" /> |
 
 ## コードの生成
 

--- a/jp/components/tabs.md
+++ b/jp/components/tabs.md
@@ -11,42 +11,42 @@ Tabs コンポーネント シンボルは、同じ情報を異なるビュー�
 
 ### Tabs デモ
 
-![](../images/tabs_demo.png)
+<img src="../images/tabs_demo.png" srcset="../images/tabs_demo@2x.png 2x" />
 
 ### サイズ
 
 バーに配置されたタブは、高さのあるテキストを使用したアイコン、または短いテキストまたはアイコンを含みますが同時に両方を含むことはありません。
 
-![](../images/tabs_short.png)
-![](../images/tabs_tall.png)
+<img src="../images/tabs_short.png" srcset="../images/tabs_short@2x.png 2x" />
+<img src="../images/tabs_tall.png" srcset="../images/tabs_tall@2x.png 2x" />
 
 ### レスポンシブ
 
 Tab は**固定**が可能で幅を変更して水平スペースを埋めることができます。フルードにも対応しており、通常より多くのコンテンツが収まり、スクロールボタンでより多くのタブを表示、スクロールできます。
 
-![](../images/tabs_fixed.png)
-![](../images/tabs_fluid.png)
+<img src="../images/tabs_fixed.png" srcset="../images/tabs_fixed@2x.png 2x" />
+<img src="../images/tabs_fluid.png" srcset="../images/tabs_fluid@2x.png 2x" />
 
 ### 合計
 
 多くのケースで Tabs に 2 項目 ～ 4 項目が必要になります。4 項目以上必要な場合、ビューでタブのみ表示するフルード モードを検討します。
 
-![](../images/tabs_2.png)
-![](../images/tabs_3.png)
-![](../images/tabs_4.png)
+<img src="../images/tabs_2.png" srcset="../images/tabs_2@2x.png 2x" />
+<img src="../images/tabs_3.png" srcset="../images/tabs_3@2x.png 2x" />
+<img src="../images/tabs_4.png" srcset="../images/tabs_4@2x.png 2x" />
 
 ### タイプ
 
 短い Tabs は、各タブの項目を説明する**テキスト**とアイコンのコンテンツをサポートします。
 
-![](../images/tabs_text.png)
-![](../images/tabs_icons.png)
+<img src="../images/tabs_text.png" srcset="../images/tabs_text@2x.png 2x" />
+<img src="../images/tabs_icons.png" srcset="../images/tabs_icons@2x.png 2x" />
 
 ### スタイル設定
 
 Tabs は、テキストやアイコンの色、現在の選択をマークするインジケーターの色、アクティブ/インアクティブな背景色の変更が可能な基本的なスタイル設定が可能です。
 
-![](../images/tabs_styling.png)
+<img src="../images/tabs_styling.png" srcset="../images/tabs_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -54,8 +54,8 @@ Tab は情報の体系化に適しいますが、ワークフローのデザイ�
 
 | いい例                          | 悪い例                         |
 | --------------------------- | ----------------------------- |
-| ![](../images/tabs_do1.png) | ![](../images/tabs_dont1.png) |
-| ![](../images/tabs_do2.png) | ![](../images/tabs_dont2.png) |
+| <img src="../images/tabs_do1.png" srcset="../images/tabs_do1@2x.png 2x" /> | <img src="../images/tabs_dont1.png" srcset="../images/tabs_dont1@2x.png 2x" /> |
+| <img src="../images/tabs_do2.png" srcset="../images/tabs_do2@2x.png 2x" /> | <img src="../images/tabs_dont2.png" srcset="../images/tabs_dont2@2x.png 2x" /> |
 
 ## その他のリソース
 

--- a/jp/components/text.md
+++ b/jp/components/text.md
@@ -11,39 +11,39 @@ Text コンポーネント シンボルは、ニュースやブログ ポスト�
 
 ### Text デモ
 
-![](../images/text_demo.png)
+<img src="../images/text_demo.png" srcset="../images/text_demo@2x.png 2x" />
 
 ### Title と Paragraph
 
 Text には、Titles と Paragraphs のためのバリアントがあります。
 
-![](../images/text_title.png)
-![](../images/text_paragraph.png)
+<img src="../images/text_title.png" srcset="../images/text_title@2x.png 2x" />
+<img src="../images/text_paragraph.png" srcset="../images/text_paragraph@2x.png 2x" />
 
 ### タイトル サイズ
 
 テキスト タイトルは、最小 H6 から最大 H1 の 6 つのプリセット サイズがあります。
 
-![](../images/text_h1.png)
-![](../images/text_h2.png)
-![](../images/text_h3.png)
-![](../images/text_h4.png)
-![](../images/text_h5.png)
-![](../images/text_h6.png)
+<img src="../images/text_h1.png" srcset="../images/text_h1@2x.png 2x" />
+<img src="../images/text_h2.png" srcset="../images/text_h2@2x.png 2x" />
+<img src="../images/text_h3.png" srcset="../images/text_h3@2x.png 2x" />
+<img src="../images/text_h4.png" srcset="../images/text_h4@2x.png 2x" />
+<img src="../images/text_h5.png" srcset="../images/text_h5@2x.png 2x" />
+<img src="../images/text_h6.png" srcset="../images/text_h6@2x.png 2x" />
 
 ### 段落サイズ
 
 テキスト段落には、ラージ **Body 1**、スモール Body 2、画像やタイトルの注釈に使用する極小キャプションがあります。
 
-![](../images/text_b1.png)
-![](../images/text_b2.png)
-![](../images/text_caption.png)
+<img src="../images/text_b1.png" srcset="../images/text_b1@2x.png 2x" />
+<img src="../images/text_b2.png" srcset="../images/text_b2@2x.png 2x" />
+<img src="../images/text_caption.png" srcset="../images/text_caption@2x.png 2x" />
 
 ### スタイル設定
 
 Titles と Paragraphs は、Styling ライブラリの Typography 部分で使用できるテキスト ウェイトや色プリセットのみから選択できます。
 
-![](../images/text_styling.png)
+<img src="../images/text_styling.png" srcset="../images/text_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -51,8 +51,8 @@ Hyperlink を複数同時に使用する場合は、Hyperlink を目立つよう
 
 | いい例                          | 悪い例                         |
 | --------------------------- | ----------------------------- |
-| ![](../images/text_do1.png) | ![](../images/text_dont1.png) |
-| ![](../images/text_do2.png) | ![](../images/text_dont2.png) |
+| <img src="../images/text_do1.png" srcset="../images/text_do1@2x.png 2x" /> | <img src="../images/text_dont1.png" srcset="../images/text_dont1@2x.png 2x" /> |
+| <img src="../images/text_do2.png" srcset="../images/text_do2@2x.png 2x" /> | <img src="../images/text_dont2.png" srcset="../images/text_dont2@2x.png 2x" /> |
 
 ## コードの生成
 

--- a/jp/components/time-picker.md
+++ b/jp/components/time-picker.md
@@ -11,34 +11,34 @@ Time Picker コンポーネント シンボルは、日付の時間部分 (時�
 
 ### Time Picker デモ
 
-![](../images/timepicker_demo.png)
+<img src="../images/timepicker_demo.png" srcset="../images/timepicker_demo@2x.png 2x" />
 
 ### レイアウト
 
 Time Picker は、水平/垂直の方向の時間選択モードをサポートします。
 
-![](../images/timepicker_horizontal.png)
-![](../images/timepicker_vertical.png)
+<img src="../images/timepicker_horizontal.png" srcset="../images/timepicker_horizontal@2x.png 2x" />
+<img src="../images/timepicker_vertical.png" srcset="../images/timepicker_vertical@2x.png 2x" />
 
 ### ボタン
 
 Time Picker の 2 つのボタンは、時間を元の時間に戻す選択のキャンセル、変更を保存するための選択の確認に使用します。Overrides で両方を none に設定してボタンレスのレイアウトを実現できます。
 
-![](../images/timepicker_buttons.png)
-![](../images/timepicker_nobuttons.png)
+<img src="../images/timepicker_buttons.png" srcset="../images/timepicker_buttons@2x.png 2x" />
+<img src="../images/timepicker_nobuttons.png" srcset="../images/timepicker_nobuttons@2x.png 2x" />
 
 ### コンテンツ
 
 Time Picker は、2 種類のコンテンツ モードで 12 時間と 24 時間をサポートします。時間と分の部分の他に 12 時間コンテンツ モードで AM と PM を選択できます。
 
-![](../images/timepicker_12.png)
-![](../images/timepicker_24.png)
+<img src="../images/timepicker_12.png" srcset="../images/timepicker_12@2x.png 2x" />
+<img src="../images/timepicker_24.png" srcset="../images/timepicker_24@2x.png 2x" />
 
 ### スタイル設定
 
 Time Picker は、さまざまなオーバーライドでヘッダー背景、タイトル色、選択した時間、分、AM/PM のテキストの色の制御などスタイル設定に柔軟性があります。Cancel と OK のボタンは、Flat Buttons で状況に応じたスタイル設定が可能です。
 
-![](../images/timepicker_styling.png)
+<img src="../images/timepicker_styling.png" srcset="../images/timepicker_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -46,8 +46,8 @@ Time Picker は、さまざまなオーバーライドでヘッダー背景、�
 
 | いい例                                | 悪い例                               |
 | --------------------------------- | ----------------------------------- |
-| ![](../images/timepicker_do1.png) | ![](../images/timepicker_dont1.png) |
-| ![](../images/timepicker_do2.png) | ![](../images/timepicker_dont2.png) |
+| <img src="../images/timepicker_do1.png" srcset="../images/timepicker_do1@2x.png 2x" /> | <img src="../images/timepicker_dont1.png" srcset="../images/timepicker_dont1@2x.png 2x" /> |
+| <img src="../images/timepicker_do2.png" srcset="../images/timepicker_do2@2x.png 2x" /> | <img src="../images/timepicker_dont2.png" srcset="../images/timepicker_dont2@2x.png 2x" /> |
 
 ## その他のリソース
 

--- a/jp/components/toast.md
+++ b/jp/components/toast.md
@@ -11,21 +11,21 @@ Toast コンポーネント シンボルは、非インタラクティブでユ�
 
 ### Toast デモ
 
-![](../images/toast_demo.png)
+<img src="../images/toast_demo.png" srcset="../images/toast_demo@2x.png 2x" />
 
 ### 位置
 
 Toast は、情報に関連するコンテンツの上、下、中央に相対的に配置します。
 
-![](../images/toast_bottom.png)
-![](../images/toast_center.png)
-![](../images/toast_top.png)
+<img src="../images/toast_bottom.png" srcset="../images/toast_bottom@2x.png 2x" />
+<img src="../images/toast_center.png" srcset="../images/toast_center@2x.png 2x" />
+<img src="../images/toast_top.png" srcset="../images/toast_top@2x.png 2x" />
 
 ### スタイル設定
 
 Toast は、スタイル設定に制限があり背景とメッセージ テキスト色のみ制御します。ただし、white と grays.900 のどちらかを選択することをお勧めします。メッセージ テキストは背景とのコントラストがより高い方を使用します。
 
-![](../images/toast_styling.png)
+<img src="../images/toast_styling.png" srcset="../images/toast_styling@2x.png 2x" />
 
 ## 使用方法
 
@@ -33,8 +33,8 @@ Toast は、常に水平に配置する必要があり、その他の配置は�
 
 | いい例                          | 悪い例                          |
 | ---------------------------- | ------------------------------ |
-| ![](../images/toast_do1.png) | ![](../images/toast_dont1.png) |
-| ![](../images/toast_do2.png) | ![](../images/toast_dont2.png) |
+| <img src="../images/toast_do1.png" srcset="../images/toast_do1@2x.png 2x" /> | <img src="../images/toast_dont1.png" srcset="../images/toast_dont1@2x.png 2x" /> |
+| <img src="../images/toast_do2.png" srcset="../images/toast_do2@2x.png 2x" /> | <img src="../images/toast_dont2.png" srcset="../images/toast_dont2@2x.png 2x" /> |
 
 ## コードの生成
 

--- a/jp/getting-started.md
+++ b/jp/getting-started.md
@@ -44,42 +44,42 @@ Indigo Design ライブラリを追加後、デザインを開始できます。
   | &nbsp;&nbsp; Image             | 背景として使用する画像 |
 
   <div class="divider--half"></div>
-  ![](images/getting-started1.png)
+  <img src="images/getting-started1.png" srcset="images/getting-started1@2x.png 2x" />
   <div class="divider--half"></div>
 
 3.  `Insert` メニューから `Indigo-Styling` > `Shadows/Rect` > `Elevate 18` を選択します。背景の上で Navbar の下に配置します。同じように `Colors/white` 長方形を挿入します。境界線がエレベーションの境界線と一致するためにサイズ変更して配置します。両方のレイヤーを選択してサイズを 280 x 400 に設定します。これでアートボードの中央に配置し、フォームのサーフェイスになります。
 
-  ![](images/getting-started2.png)
+  <img src="images/getting-started2.png" srcset="images/getting-started2@2x.png 2x" />
 
   <div class="divider--half"></div>
 
 4.  `Insert` メニューから `Indigo-Components` > `Text` > `Title` を選択します。このサーフェイス上に配置し、左、上、右に 16px スペースを設定します。新しく挿入したレイヤーがサーフェイス上で NavBar の下に表示されます。`Size` オーバーライドを `H4` に設定し、`Style` を `~34/left/Primary` に設定し、`Text` を "Start Budgeting" に設定します。最後に、このレイヤーの高さを 56px に設定します。
 
-  ![](images/getting-started3.png)
+  <img src="images/getting-started3.png" srcset="images/getting-started3@2x.png 2x" />
 
   <div class="divider--half"></div>
 
 5.  `Insert` メニューから `Indigo-Components` > `Inputs/Input` > `Line` を選択します。キャンバスおよびレイヤー パネルでタイトルの下に配置します。左に 16px を設定し、上の Title から 0px を設定し、幅を 116px に設定します。この入力を複製し、既存の入力の右に配置します。左側および右側に 16px スペースを設定します。両方の Input を選択し、`State` オーバーライドを `~Dark/Filled` に設定します。次に左の Input のラベルを "First Name" に設定し、`Input Text` を "Eliza" に設定します。右の Input のラベルを "Last Name" に設定し、`Input Text` を "Morales" に設定します。以下のようになります。
 
-  ![](images/getting-started4.png)
+  <img src="images/getting-started4.png" srcset="images/getting-started4@2x.png 2x" />
 
   <div class="divider--half"></div>
 
 6.  2 つの Line Input を挿入します。以前の手順の入力の下に配置します。`State` オーバーライドを `~Dark/Filled` に設定し、幅全体に引き伸ばし、左右のスペースを 16px に設定します。`Label` を "Username" および "Password" に設定し、`Input Text` を "Leaellynasaura" および "\*\*\*\*\*\*\*\*\*\*\*\*" に設定します。
 
-  ![](images/getting-started5.png)
+  <img src="images/getting-started5.png" srcset="images/getting-started5@2x.png 2x" />
 
   <div class="divider--half"></div>
 
 7.  `Insert` メニューから `Indigo-Components` > `Buttons` > `Raised` を選択し、作成したフォームの下に配置します。左に 16px を設定し、上の Inputs から 0px を設定し、右に 16px に設定します。`Text` を "SIGN UP" に設定し、`Background` を `Colors/info` に設定します。
 
-  ![](images/getting-started6.png)
+  <img src="images/getting-started6.png" srcset="images/getting-started6@2x.png 2x" />
 
   <div class="divider--half"></div>
 
 8.  `Insert` メニューから `Indigo-Components` > `Text` > `Paragraph` を選択し、ボタンの下に配置し、すべての側に 16px スペースを設定するためにサイズ変更します。`Size` オーバーライドを `Body 2` に設定し、`Style` を `~14/left/grays.700` に設定します。`Text` を「By clicking on the "SIGN UP" button above, you accept our Terms of Use」に設定します。
 
-  ![](images/getting-started7.png)
+  <img src="images/getting-started7.png" srcset="images/getting-started7@2x.png 2x" />
 
   <div class="divider--half"></div>
 

--- a/jp/patterns/av.md
+++ b/jp/patterns/av.md
@@ -9,8 +9,8 @@ _language: ja
 
 AV パターンは再生コントロールを持つオーディオまたはビデオ トラック表示と共に使用されます。
 
-![](../images/av_player_demo.png)
-![](../images/av_volume_demo.png)
+<img src="../images/av_player_demo.png" srcset="../images/av_player_demo@2x.png 2x" />
+<img src="../images/av_volume_demo.png" srcset="../images/av_volume_demo@2x.png 2x" />
 
 AV パターンのレイアウトに含まれる Icon Buttons および Linear Progress Bar のスタイル設定を使用できます。
 

--- a/jp/patterns/avatar-badge.md
+++ b/jp/patterns/avatar-badge.md
@@ -9,7 +9,7 @@ _language: ja
 
 Avatar + Badge パターンは、Avatar にアラートまたは通知のメッセージやインジケーターを追加します。
 
-![](../images/avatar_badge_demo.png)
+<img src="../images/avatar_badge_demo.png" srcset="../images/avatar_badge_demo@2x.png 2x" />
 
 Avatar + Badge パターンは、レイアウトに含まれる Avatar および Badge のスタイル設定をカスタマイズできます。
 
@@ -25,7 +25,7 @@ Avatar + Badge パターンは Avatar と同じサイズをサポートします
 
 Badge はオーバーライドによって Avatar の 4 つ角のいずれかに配置できます。
 
-![](../images/avatar_badge_positions.png)
+<img src="../images/avatar_badge_positions.png" srcset="../images/avatar_badge_positions@2x.png 2x" />
 
 ## その他のリソース
 

--- a/jp/patterns/card-collection.md
+++ b/jp/patterns/card-collection.md
@@ -9,10 +9,10 @@ _language: ja
 
 Card Collection パターンを使用すると、アシスタントまたはニュース フィード、タイムライン、または複数列ボードを表示できます。
 
-![](../images/cardcol_demo_assistant.png)
-![](../images/cardcol_demo_news.png)
-![](../images/cardcol_demo_pins.png)
-![](../images/cardcol_demo_timeline.png)
+<img src="../images/cardcol_demo_assistant.png" srcset="../images/cardcol_demo_assistant@2x.png 2x" />
+<img src="../images/cardcol_demo_news.png" srcset="../images/cardcol_demo_news@2x.png 2x" />
+<img src="../images/cardcol_demo_pins.png" srcset="../images/cardcol_demo_pins@2x.png 2x" />
+<img src="../images/cardcol_demo_timeline.png" srcset="../images/cardcol_demo_timeline@2x.png 2x" />
 
 Card Collection パターンは Card の様々なタイプおよび (ある場合) Searchbar Input のスタイル設定をカスタマイズできます。
 

--- a/jp/patterns/checkbox-group.md
+++ b/jp/patterns/checkbox-group.md
@@ -9,7 +9,7 @@ _language: ja
 
 Checkbox Group パターンを使用すると、Checkbox 要素のコレクションをグループとして配置します。たとえば、複数選択質問の答えを含むグループを作成できます。
 
-![](../images/checkbox-group_demo.png)
+<img src="../images/checkbox-group_demo.png" srcset="../images/checkbox-group_demo@2x.png 2x" />
 
 > [!Note]
 > 提供される項目より多い項目を作成する場合のみに Checkbox Group パターンのインスタンスで `Detach From Symbol` をトリガーします。

--- a/jp/patterns/details.md
+++ b/jp/patterns/details.md
@@ -9,7 +9,7 @@ _language: ja
 
 Details パターンを使用すると、記事、製品、レシピなどを全画面表示ページで詳細情報を表示します。
 
-![](../images/details_demo.png)
+<img src="../images/details_demo.png" srcset="../images/details_demo@2x.png 2x" />
 
 Details パターンは、含まれる Badge、Button、Tab、および Text 要素のスタイル設定をカスタマイズできます。
 
@@ -17,7 +17,7 @@ Details パターンは、含まれる Badge、Button、Tab、および Text 要
 
 Details Pattern はレイアウトに含まれる以下の利用可能な要素をサポートします: Action Bar、Badge、Description、Metadata、Tabs、Title、および Price。
 
-![](../images/details_content.png)
+<img src="../images/details_content.png" srcset="../images/details_content@2x.png 2x" />
 
 ## その他のリソース
 

--- a/jp/patterns/file-upload.md
+++ b/jp/patterns/file-upload.md
@@ -9,7 +9,7 @@ _language: ja
 
 File Upload パターンを使用すると、ファイル、画像、添付などのアップロードおよび挿入機能を提供します。
 
-![](../images/file-upload_demo.png)
+<img src="../images/file-upload_demo.png" srcset="../images/file-upload_demo@2x.png 2x" />
 
 File Upload パターンは、レイアウトに含まれる Avatar および Icon Button のスタイル設定をカスタマイズできます。
 
@@ -17,13 +17,13 @@ File Upload パターンは、レイアウトに含まれる Avatar および Ic
 
 File Upload パターンはアップロードしたファイルのプレビューのために 2 種類 (Avatar および規格の画像として表示される Document) あります。 
 
-![](../images/file-upload_type.png)
+<img src="../images/file-upload_type.png" srcset="../images/file-upload_type@2x.png 2x" />
 
 ### コンテンツ
 
 File Upload パターンは、アップロードまたは Document として挿入されるよく使用されるコンテンツ タイプ (CSV、PDF、Presentation、Spreadsheet Text) をサポートします。 また、様々なアプリケーション シナリオのカスタマイズ化を提供するために Upload および Attach タイプの利用が可能です。
 
-![](../images/file-upload_content.png)
+<img src="../images/file-upload_content.png" srcset="../images/file-upload_content@2x.png 2x" />
 
 ## その他のリソース
 

--- a/jp/patterns/form.md
+++ b/jp/patterns/form.md
@@ -9,7 +9,7 @@ _language: ja
 
 Form パターンを使用すると、複数のユーザー入力が必要なアプリケーション シナリオを実装できます。全般的なフォームでデータ入力および表示コンポーネントが使用されます。
 
-![](../images/form_demo.png)
+<img src="../images/form_demo.png" srcset="../images/form_demo@2x.png 2x" />
 
 Form パターンのレイアウトに含まれる Input、Checkbox、Button、Hyperlink、および Text のスタイル設定を使用できます。
 
@@ -17,7 +17,7 @@ Form パターンのレイアウトに含まれる Input、Checkbox、Button、H
 
 Form パターンは 2 つのメイン領域に分割されます。Inputs 領域は入力する情報を含むメイン コンテンツ領域です。Actions 領域は「利用規約」または「アカウントを記憶する」チェックボックス、「パスワード忘れ」リンク、またはフォーム送信のボタンなどの操作が配置される領域です。Actions 領域は選択可能な項目の 3 つの行に配置されます。選択可能な項目は Button、Checkbox、Link、Text Area、またはデフォルトでボタンとして表示されるが、以前の項目の組み合わせが可能な Two Actions。
 
-![](../images/form_content.png)
+<img src="../images/form_content.png" srcset="../images/form_content@2x.png 2x" />
 
 Form パターンはログインと登録、予約、アドレス、支払、およびコンテンツの追加のための新規などの全般的なシナリオのフォームを提供します。
 
@@ -25,32 +25,32 @@ Form パターンはログインと登録、予約、アドレス、支払、お
 
 ログインと登録フォームは 2 つのグループで配置されます。両方が Content および Action 領域がある簡単なレイアウトがあり、またはソーシャル ログインまたは登録のための追加の Action 領域を含む高度なレイアウトがあります。
 
-![](../images/form_login-simple.png)
-![](../images/form_login-social.png)
+<img src="../images/form_login-simple.png" srcset="../images/form_login-simple@2x.png 2x" />
+<img src="../images/form_login-social.png" srcset="../images/form_login-social@2x.png 2x" />
 
 ログイン フォームにも水平レイアウトがあり、レイアウトの Button および Hyperlink コンテンツを更新した後に登録フォームをカスタマイズできます。このレイアウトは幅が広い画面に最適です。フォームがその他のコンテンツとインラインに表示されます。
 
-![](../images/form_login-horizontal.png)
-![](../images/form_register-horizontal.png)
+<img src="../images/form_login-horizontal.png" srcset="../images/form_login-horizontal@2x.png 2x" />
+<img src="../images/form_register-horizontal.png" srcset="../images/form_register-horizontal@2x.png 2x" />
 
 ##### 予約フォーム
 
 Inputs オーバーライドで選択可能な予約フォームプリセットが 4 つあります。**Dates + People** は全般的なフォームです。Dates + People + Rooms はホテルの予約に使用できます。Airports + Dates + People は飛行機のチケットやその他の乗車券の予約に使用できます。Location + People + Rooms もホテル予約に使用できます。
 
-![](../images/form_booking.png)
+<img src="../images/form_booking.png" srcset="../images/form_booking@2x.png 2x" />
 
 ##### 新規フォーム
 
 Inputs オーバーライドで選択可能な新規フォームの 2 種類があります。**Expense** は新しい経費の作成のための情報フォームです。Budget は新しい予算の作成のための情報フォームです。
 
-![](../images/form_new.png)
+<img src="../images/form_new.png" srcset="../images/form_new@2x.png 2x" />
 
 ##### 支払フォーム
 
 支払フォームの 2 種類があります。クレジット カードの支払フォームおよびオンライン銀行で現金の支払フォームがあります。現金転送フォームは Inputs オーバーライドで選択可能な 4 つのレイアウトを提供します。 **Currency Exchange** は為替換算のフィールドを含みます。Donation は慈善のフォームです。Between Accounts は同じ銀行で複数のアカウントの間の送金に使用できます。Between Banks は他の銀行への送金に使用できます。
 
-![](../images/form_card.png)
-![](../images/form_cash.png)
+<img src="../images/form_card.png" srcset="../images/form_card@2x.png 2x" />
+<img src="../images/form_cash.png" srcset="../images/form_cash@2x.png 2x" />
 
 ## その他のリソース
 

--- a/jp/patterns/gallery.md
+++ b/jp/patterns/gallery.md
@@ -9,23 +9,23 @@ _language: ja
 
 Gallery パターンを使用すると、画像がアルバムに配置される画像グリッドを表示します。以下の画像サイズをサポートします。
 
-![](../images/gallery_large.png)
+<img src="../images/gallery_large.png" srcset="../images/gallery_large@2x.png 2x" />
 
 **Large** - 行ごとに 4 画像
 
-![](../images/gallery_medium.png)
+<img src="../images/gallery_medium.png" srcset="../images/gallery_medium@2x.png 2x" />
 
 Medium - 行ごとに 3 画像
 
-![](../images/gallery_small.png)
+<img src="../images/gallery_small.png" srcset="../images/gallery_small@2x.png 2x" />
 
 Small - 行ごとに 4 画像
 
-![](../images/gallery_very-small.png)
+<img src="../images/gallery_very-small.png" srcset="../images/gallery_very-small@2x.png 2x" />
 
 Very Small- 行ごとに 4 画像
 
-![](../images/gallery_flexible.png)
+<img src="../images/gallery_flexible.png" srcset="../images/gallery_flexible@2x.png 2x" />
 
 Flexible - 行ごとに 4 画像
 

--- a/jp/patterns/image-manipulation.md
+++ b/jp/patterns/image-manipulation.md
@@ -9,7 +9,7 @@ _language: ja
 
 Image Manipulation パターンを使用すると、画像または写真を含む Avatar を編集、更新、変更、またはその他のクイック アクションを実行できます。
 
-![](../images/image-manip_demo.png)
+<img src="../images/image-manip_demo.png" srcset="../images/image-manip_demo@2x.png 2x" />
 
 Image Manipulation パターンは、レイアウトに含まれる Avatar および複数の Button のスタイル設定をカスタマイズできます。
 
@@ -17,7 +17,7 @@ Image Manipulation パターンは、レイアウトに含まれる Avatar お�
 
 Image Manipulation パターンは 1 ～ 2 Flat Button、FAB Button、または Icon Button を含むレイアウトで規格の画像および Avatar をサポートします。
 
-![](../images/image-manip_layout.png)
+<img src="../images/image-manip_layout.png" srcset="../images/image-manip_layout@2x.png 2x" />
 
 ## その他のリソース
 

--- a/jp/patterns/lists.md
+++ b/jp/patterns/lists.md
@@ -9,9 +9,9 @@ _language: ja
 
 Lists パターン シンボルは、フィルター可能な設定、人、ミュージック プレイリスト、製品、検索可能なリスト、設定などの全般的なシナリオを表示するデータ コレクションのプリセットとして使用できます。
 
-![](../images/lists_people.png)
-![](../images/lists_products.png)
-![](../images/lists_settings.png)
+<img src="../images/lists_people.png" srcset="../images/lists_people@2x.png 2x" />
+<img src="../images/lists_products.png" srcset="../images/lists_products@2x.png 2x" />
+<img src="../images/lists_settings.png" srcset="../images/lists_settings@2x.png 2x" />
 
 Lists パターンは List Item の様々なタイプおよび (ある場合) Searchbar Input のスタイル設定をカスタマイズできます。
 

--- a/jp/patterns/user-profile.md
+++ b/jp/patterns/user-profile.md
@@ -9,8 +9,8 @@ _language: ja
 
 User Profile パターンを使用すると、全画面表示の詳細ページまたはヘッダーまたはツールバーに挿入する小さいインジケーターでユーザーに関連する情報を表示します。
 
-![](../images/profile_demo.png)
-![](../images/profile_small.png)
+<img src="../images/profile_demo.png" srcset="../images/profile_demo@2x.png 2x" />
+<img src="../images/profile_small.png" srcset="../images/profile_small@2x.png 2x" />
 
 User Profile パターンの編集可能なバリアントもあります。User Profile パターンは、レイアウトに含まれる Avatar、Text、および Input のスタイル設定をカスタマイズできます。
 

--- a/jp/style/colors.md
+++ b/jp/style/colors.md
@@ -9,13 +9,13 @@ _language: ja
 
 Colors はテーマ色 (`primary`、`secondary`、`success`、`warn`、`error`、`info`) を設定します。Styling ライブラリで Colors を設定する方法は、[Ignite UI for Angular Themes](https://jp.infragistics.com/products/ignite-ui-angular/angular/components/themes.html) と同じです。
 
-![](../images/colors_palette.png)
+<img src="../images/colors_palette.png" srcset="../images/colors_palette@2x.png 2x" />
 
 ### パレット生成
 
 プライマリ カラーを変更するには、Sketch ファイルの `Colors` ページに移動し、`Primary 500` シンボルを適切な色に変更します。プライマリ パレット全体が直ちに更新されます。同じパレット生成が二次色にも使用できます。
 
-![](../images/colors_generation.png)
+<img src="../images/colors_generation.png" srcset="../images/colors_generation@2x.png 2x" />
 
 > [!Note]
 > テキスト色は、デフォルト テーマをすべて更新する際に `Typography` で制御されるため、`Typography` ページの色を手動で変更する必要があります。プライマリ カラーを変更後、Typography の `Primary` セクションを同じ色に変更してください。手順の詳細は、[Typography](typography.md) をご確認ください。
@@ -30,15 +30,15 @@ Colors はテーマ色 (`primary`、`secondary`、`success`、`warn`、`error`�
 
 1.  Styling ライブラリを開き、`Colors` へ移動して色シンボルの `black`/`white`/`transparent` の行の下の空の `Custom` セクションにズームします。
 
-    ![](../images/colors_custom0.png)
+    <img src="../images/colors_custom0.png" srcset="../images/colors_custom0@2x.png 2x" />
 
 2.  `Colors/black` シンボルを選択、次に `option` キーを押しながら以下のシンボルにドラッグし、コピーを作成します。
 
-    ![](../images/colors_custom1.png)
+    <img src="../images/colors_custom1.png" srcset="../images/colors_custom1@2x.png 2x" />
 
 3.  `Colors/black` コピー シンボルの 唯一のレイヤーである `Rectangle` レイヤーを選択して、Fill の色を #008080 (teal) などに変更できます。`Colors/teal` などシンボルの名前も変更する必要があります。
 
-    ![](../images/colors_custom2.png)
+    <img src="../images/colors_custom2.png" srcset="../images/colors_custom2@2x.png 2x" />
 
 4.  ライブラリで変更を保存し、追加した色はライブラリ メニューの色リストに表示されます。Components および Patterns ライブラリで色が使用されている場所に色オーバーライドに表示されます。
 
@@ -48,19 +48,19 @@ Colors はテーマ色 (`primary`、`secondary`、`success`、`warn`、`error`�
 
 1.  既存の Sketch ファイルを開いて新しいページを作成し、ページ名を `Local Styles` にします。新しいページで Styling ライブラリから `Colors/black` 要素を挿入します。
 
-    ![](../images/colors_local0.png)
+    <img src="../images/colors_local0.png" srcset="../images/colors_local0@2x.png 2x" />
 
 2.  右クリックして`シンボルからデタッチ`を選択して `Rectangle` と呼ばれるレイヤーのみ含まれます。`Rectangle` レイヤーを選択して Fill の色を #008080 (teal) などに変更します。
 
-    ![](../images/colors_local1.png)
+    <img src="../images/colors_local1.png" srcset="../images/colors_local1@2x.png 2x" />
 
 3.  `シンボルからデタッチ`を選択して作成したグループ (以前のシンボル インスタンスと同じように `Colors/black` と呼ばれる) を選択し、メイン Sketch トップ メニューから `Create Symbol` ボタンをクリックして変更した色を色シンボルをオーバライドとして再度インスタンスを作成します。カスタム色 (`Colors/teal` など) の名前を選択するプロンプトが表示されます。Symbols Page チェックボックスのチェックは、OK ボタンをクリックする前に外されます。シンボルが作成され、以下のようになります。
 
-    ![](../images/colors_local2.png)
+    <img src="../images/colors_local2.png" srcset="../images/colors_local2@2x.png 2x" />
 
 4.  シンボル以外のティール色の四角形を削除して完了です。追加した色は、Document カテゴリの色のリストでローカル シンボルとして表示されます。現在のプロジェクトで色が使用できる Components および Patterns のすべてのインスタンスの `Document/Colors` の色オーバーライドにも表示されます。
 
-    ![](../images/colors_local3.png)
+    <img src="../images/colors_local3.png" srcset="../images/colors_local3@2x.png 2x" />
 
 ## コードの生成
 

--- a/jp/style/elevation.md
+++ b/jp/style/elevation.md
@@ -19,7 +19,7 @@ _language: ja
 
 エレベーションの数値が大きくなると、シャドウがより暗く表示されます。シャドウは umbra、penumbra、および ambient の 3 つが重なったシャドウ色の組み合わせで値はマテリアル デザインの定義と一致します。
 
-![](../images/elevation_people.png)
+<img src="../images/elevation_people.png" srcset="../images/elevation_people@2x.png 2x" />
 
 > [!Note]
 > Sketch でコンポーネントをオーバーライドしてエレベーションを変更することは可能ですが、現在 Ignite UI for Angular では実装されていません。
@@ -28,7 +28,7 @@ _language: ja
 
 コンテンツ部分をフォーカスするためにエレベーションを使用できます。その場合、使用するエレベーションをドラッグして、対象のコンテンツのサイズと合わせます。
 
-![](../images/elevation_standalone.png)
+<img src="../images/elevation_standalone.png" srcset="../images/elevation_standalone@2x.png 2x" />
 
 ## その他のリソース
 

--- a/jp/style/material-icons.md
+++ b/jp/style/material-icons.md
@@ -9,7 +9,7 @@ _language: ja
 
 Icon Buttons、List Items、Cards などで全般的な操作を記号として表示するためにマテリアル アイコンを使用します。たとえば、Button ラベルでテキストの代わりにアイコンを使用します。マテリアル アイコンはスタイリングのカラー シンボルを使用します。デザインするアイコンのために定義済みの色を選択できます。スタイリング ライブラリに追加されるアイコンのセットは[マテリアル アイコン](https://material.io/tools/icons/?style=baseline)と同じ要素のサブセットで、[Ignite UI for Angular](https://jp.infragistics.com/products/ignite-ui-angular) にサポートされます。
 
-![](../images/icons_demo.png)
+<img src="../images/icons_demo.png" srcset="../images/icons_demo@2x.png 2x" />
 
 > [!Note]
 > コンポーネント ライブラリは 4 つのアイコン サイズ (ExtraLarge、Large、Medium、および Small) で [Icon](icon.md) シンボルを提供します。記事、カスタム Card および List Item の高度なレイアウトを作成で直接スタイリング ライブラリを使用する代わりにこのアイコンを使用します。
@@ -41,7 +41,7 @@ Icon Buttons、List Items、Cards などで全般的な操作を記号として�
 
 1.  ブラウザーで[マテリアル デザイン アイコン ツール](https://material.io/tools/icons)に移動します。「`copyright`」などに使用するアイコンを検索し、SVG としてダウンロードして「`Action`」などのカテゴリを確認します。Sketch でスタイリング ライブラリを開き、左側にそのカテゴリがテキスト レイヤーとして存在するかどうかを確認します。存在しない場合は作成して、以下の手順を行います。「`Action`」カテゴリの `copyright` アイコンの例のように存在する場合、そのカテゴリの最も右側にあるアイコンを検索します。
 
-  ![](../images/icons_add1.png)
+  <img src="../images/icons_add1.png" srcset="../images/icons_add1@2x.png 2x" />
 
 2.  このアイコンのシンボルをコピーして右へ移動します。名前が「`...Copy`」と終了し、構造がシンボルのグループで以下のようになります。
 
@@ -52,15 +52,15 @@ Icon Buttons、List Items、Cards などで全般的な操作を記号として�
   | &nbsp;&nbsp; Shape      | アイコンの図形を定義         |
   | &nbsp;&nbsp; Shape      | 境界ボックスを定義する長方形 |
 
-  ![](../images/icons_add2.png)
+  <img src="../images/icons_add2.png" srcset="../images/icons_add2@2x.png 2x" />
 
 3.  既存のアイコン図形をダウンロードした SVG と置き換えます。アイコン図形の Shape レイヤーを選択し、`copyright` アイコンの SVG をその上にドラッグ アンド ドロップします。これはアイコン名の新しいグループをレイヤー パネルに作成します。このグループを展開し、アイコン図形をグループ以外で元のアイコン図形の上にドラッグします。
 
-  ![](../images/icons_add3.png)
+  <img src="../images/icons_add3.png" srcset="../images/icons_add3@2x.png 2x" />
 
 4.  新しいアイコン図形を移動した後、元のアイコン図形およびグループを削除します。`copyright` 記号のアイコン図形を選択し、境界線および塗りつぶしを削除して、マスクのみとして使用されることを確認します。グループを `copyright` に名前変更し、シンボルを `icons/action/copyright` に名前変更した後、このアイコンを使用できます。
 
-  ![](../images/icons_add4.png)
+  <img src="../images/icons_add4.png" srcset="../images/icons_add4@2x.png 2x" />
 
 ## その他のリソース
 

--- a/jp/style/styling-overview.md
+++ b/jp/style/styling-overview.md
@@ -11,11 +11,11 @@ _language: ja
 
 Sketch ライブラリで NBL スタイル ライブラリを変更して Components と Patterns と同じ結果となります。
 
-![](../images/theme_overview_default.png)
+<img src="../images/theme_overview_default.png" srcset="../images/theme_overview_default@2x.png 2x" />
 
-![](../images/theme_overview_dark.png)
+<img src="../images/theme_overview_dark.png" srcset="../images/theme_overview_dark@2x.png 2x" />
 
-![](../images/theme_overview_vibrant.png)
+<img src="../images/theme_overview_vibrant.png" srcset="../images/theme_overview_vibrant@2x.png 2x" />
 
 ## NBL-スタイリング
 

--- a/jp/style/typography.md
+++ b/jp/style/typography.md
@@ -9,7 +9,7 @@ _language: ja
 
 タイポグラフィを使用してテーマの書体および利用可能なサイズを設定します。[Titillium Web](https://fonts.google.com/specimen/Titillium+Web) をデフォルト書体として使用されますが、デザイナーがアプリケーションをカスタマイズできます。スタイリング ライブラリのタイポグラフィは [Ignite UI for Angular テーマ](https://jp.infragistics.com/products/ignite-ui-angular/angular/components/themes.html)で実装されるタイポグラフィと一致します。
 
-![](../images/typography_default.png)
+<img src="../images/typography_default.png" srcset="../images/typography_default@2x.png 2x" />
 
 > [!Note]
 > コンポーネント ライブラリは Title および Paragraph の [Text](text.md) シンボルを提供します。記事、ブログ投稿の高度なレイアウトの作成で直接にスタイリング ライブラリを使用する代わりにこのアイコンを使用します。タイポグラフィは、デザインのすべてのテキストで一貫性のあるテーマおよびスタイルを定義します。
@@ -18,25 +18,25 @@ _language: ja
 
 タイポグラフィは `grays.900`、`grays.600`、`white`、`primary`、および `secondary` などのプリセット色があります。`success`、`warn`、および `error` 色の文字列のためのタイポグラフィを含む追加のセットがあり、以下のセクションに説明したコンポーネント固有のバリアントもあります。
 
-![](../images/typography_colors.png)
+<img src="../images/typography_colors.png" srcset="../images/typography_colors@2x.png 2x" />
 
 ### コンポーネント固有のタイポグラフィ
 
 [Avatar](avatar.md)、[Hyperlink](hyperlink.md)、[Text](text.md) などのコンポーネントは仕様のコンポーネント固有のタイポグラフィを使用します。たとえば、Avatar は複数の色を使用し、Hyperlink は下線テキストを使用します。
 
-![](../images/typography_specific.png)
+<img src="../images/typography_specific.png" srcset="../images/typography_specific@2x.png 2x" />
 
 ### 書体の変更
 
 書体を変更するには、`Command` キーを押して、Typography セクション全体にマウスをドラッグします。これはテキスト レイヤーを選択します。(キーを押さない場合、アートボードを選択します。)書体を変更します。すべてのテキスト レイヤーが設定されます。
 
-![](../images/typography_typeface.png)
+<img src="../images/typography_typeface.png" srcset="../images/typography_typeface@2x.png 2x" />
 
 ### タイポグラフィの色の変更
 
 アプリケーションのテーマで `primary` 色および `secondary` 色を更新した後、テキスト色が自動的に更新されないことに注意してください。テキスト色も更新するには、`Command` キーを押して、`primary` または `secondary` セクション全体にマウスをドラッグします。これはテキスト レイヤーを選択します。(キーを押さない場合、アートボードを選択します。)テキスト色を変更します。テーマの必要な色のためにこの手順を繰り返します。
 
-![](../images/typography_primary.png)
+<img src="../images/typography_primary.png" srcset="../images/typography_primary@2x.png 2x" />
 
 > [!Note]
 > 以上の手順で、`grays.600` の代わりに `grays.700` を使用する場合、変更するレイヤーの名前を `Typography/../grays.700` に更新します。


### PR DESCRIPTION
Closes #25.

It turned out there is a native browser property for this - `srcset`. You can read more about it and its support [here](https://caniuse.com/#search=srcset). It does not support IE 11. So at the time being we won't be supporting crisp images in IE 11 opened on a retina display. We can make a separate GitHub issue for IE 11 retina images support.

All of the image tags are replaced by a tool I created, so please test all of the pages before verifying this PR.