### PR TITLE
Updated Secondary Nav links and added global var for indigo product t…

### DIFF
--- a/en/global.json
+++ b/en/global.json
@@ -1,4 +1,5 @@
 {
     "_navBarTitle": "Indigo.Design",
-    "_navBarTitleHref": "https://www.infragistics.com/design"
+    "_navBarTitleHref": "https://www.infragistics.com/design",
+    "_productThemeName": "indigo-design"
 }

--- a/en/toc.yml
+++ b/en/toc.yml
@@ -1,5 +1,9 @@
 - name: How to Buy
   href: 'https://www.infragistics.com/products/indigo-design/pricing'
-- name: Sign Up
+- name: Sign In
+  href: 'https://cloud.indigo.design/login'
+  cta: true
+  ctaSecondary: true
+- name: Sign Up For Free
   href: 'https://cloud.indigo.design/register'
   cta: true

--- a/jp/global.json
+++ b/jp/global.json
@@ -1,4 +1,5 @@
 {
     "_navBarTitle": "Indigo.Design",
-    "_navBarTitleHref": "https://jp.infragistics.com/design"
+    "_navBarTitleHref": "https://jp.infragistics.com/design",
+    "_productThemeName": "indigo-design"
 }

--- a/jp/toc.yml
+++ b/jp/toc.yml
@@ -1,6 +1,6 @@
 ﻿- name: 購入
   href: 'https://jp.infragistics.com/products/indigo-design/pricing'
-- name: Sign In
+- name: ログイン
   href: 'https://cloud.indigo.design/login'
   cta: true
   ctaSecondary: true

--- a/jp/toc.yml
+++ b/jp/toc.yml
@@ -1,5 +1,9 @@
 ﻿- name: 購入
   href: 'https://jp.infragistics.com/products/indigo-design/pricing'
+- name: Sign In
+  href: 'https://cloud.indigo.design/login'
+  cta: true
+  ctaSecondary: true
 - name: サインアップ
   href: 'https://cloud.indigo.design/register'
   cta: true


### PR DESCRIPTION
I've updated the secondary navigation links and I am currently pointing to the production links (@pamelabrasil if we need to switch to using staging temporarily, let me know.).

the changes includes:
1. global.json - added new _productThemeName variable to set the data-theme attribute to the value I use in this file.
2. toc.yml - added new secondary nav links: How to Buy, Sign in and Sign up for Free.

@tiliev this change is dependent on this PR (https://github.com/IgniteUI/igniteui-docfx-template/pull/19). Once the new template update is released, let me know and I can update the version number.