### PR TITLE
Fixed links

### DIFF
--- a/en/patterns/av.md
+++ b/en/patterns/av.md
@@ -23,8 +23,8 @@ The AV Pattern comes with the styling flexibility provided by the Icon Buttons a
 
 Related topics:
 
-- [Button](button.md)
-- [Progress](progress.md)
+- [Button](../components/button.md)
+- [Progress](../components/progress.md)
   <div class="divider--half"></div>
 
 Our community is active and always welcoming to new ideas.

--- a/en/patterns/avatar-badge.md
+++ b/en/patterns/avatar-badge.md
@@ -35,8 +35,8 @@ The Badge can be positioned in any of the four corners of the Avatar as shown be
 
 Related topics:
 
-- [Avatar](avatar.md)
-- [Badge](badge.md)
+- [Avatar](../components/avatar.md)
+- [Badge](../components/badge.md)
   <div class="divider--half"></div>
 
 Our community is active and always welcoming to new ideas.

--- a/en/patterns/card-collection.md
+++ b/en/patterns/card-collection.md
@@ -24,8 +24,8 @@ The Card Collection Pattern comes with the styling flexibility provided by the v
 
 Related topics:
 
-- [Cards](cards.md)
-- [Input](input.md)
+- [Cards](../components/cards.md)
+- [Input](../components/input.md)
   <div class="divider--half"></div>
 
 Our community is active and always welcoming to new ideas.

--- a/en/patterns/checkbox-group.md
+++ b/en/patterns/checkbox-group.md
@@ -24,7 +24,7 @@ The Checkbox Group Pattern comes with the styling flexibility provided by the Ch
 
 Related topics:
 
-- [Checkbox](checkbox.md)
+- [Checkbox](../components/checkbox.md)
   <div class="divider--half"></div>
 
 Our community is active and always welcoming to new ideas.

--- a/en/patterns/details.md
+++ b/en/patterns/details.md
@@ -27,10 +27,10 @@ The Details Pattern supports the following interchangeable pieces of content tha
 
 Related topics:
 
-- [Badge](badge.md)
-- [Button](button.md)
-- [Tabs](tabs.md)
-- [Text](text.md)
+- [Badge](../components/badge.md)
+- [Button](../components/button.md)
+- [Tabs](../components/tabs.md)
+- [Text](../components/text.md)
   <div class="divider--half"></div>
 
 Our community is active and always welcoming to new ideas.

--- a/en/patterns/file-upload.md
+++ b/en/patterns/file-upload.md
@@ -33,8 +33,8 @@ The File Upload Pattern supports the most common types of content that are usual
 
 Related topics:
 
-- [Avatar](avatar.md)
-- [Button](button.md)
+- [Avatar](../components/avatar.md)
+- [Button](../components/button.md)
   <div class="divider--half"></div>
 
 Our community is active and always welcoming to new ideas.

--- a/en/patterns/form.md
+++ b/en/patterns/form.md
@@ -60,11 +60,11 @@ There are two main types of Payment forms: one for Card payments and one for Cas
 
 Related topics:
 
-- [Button](button.md)
-- [Checkbox](checkbox.md)
-- [Hyperlink](hyperlink.md)
-- [Input](input.md)
-- [Text](text.md)
+- [Button](../components/button.md)
+- [Checkbox](../components/checkbox.md)
+- [Hyperlink](../components/hyperlink.md)
+- [Input](../components/input.md)
+- [Text](../components/text.md)
   <div class="divider--half"></div>
 
 Our community is active and always welcoming to new ideas.

--- a/en/patterns/full-grid.md
+++ b/en/patterns/full-grid.md
@@ -24,7 +24,7 @@ Use the Grid Pattern symbol as an alternative starting point when designing a ta
 
 Related topics:
 
-- [Grid](grid.md)
+- [Grid](../components/grid.md)
 
 Our community is active and always welcoming to new ideas.
 

--- a/en/patterns/image-manipulation.md
+++ b/en/patterns/image-manipulation.md
@@ -27,8 +27,8 @@ The Image Manipulation Pattern supports both standard images and Avatars that co
 
 Related topics:
 
-- [Avatar](avatar.md)
-- [Button](button.md)
+- [Avatar](../components/avatar.md)
+- [Button](../components/button.md)
   <div class="divider--half"></div>
 
 Our community is active and always welcoming to new ideas.

--- a/en/patterns/lists.md
+++ b/en/patterns/lists.md
@@ -25,8 +25,8 @@ The Lists Pattern comes with the styling flexibility provided by the various typ
 
 Related topics:
 
-- [Input](input.md)
-- [List](list.md)
+- [Input](../components/input.md)
+- [List](../components/list.md)
   <div class="divider--half"></div>
 
 Our community is active and always welcoming to new ideas.

--- a/en/patterns/user-profile.md
+++ b/en/patterns/user-profile.md
@@ -22,9 +22,9 @@ An editable variant of the User Profile Pattern, nicely laid out with the approp
 
 Related topics:
 
-- [Avatar](avatar.md)
-- [Text](text.md)
-- [Input](input.md)
+- [Avatar](../components/avatar.md)
+- [Text](../components/text.md)
+- [Input](../components/input.md)
   <div class="divider--half"></div>
 
 Our community is active and always welcoming to new ideas.

--- a/en/style/elevation.md
+++ b/en/style/elevation.md
@@ -33,9 +33,9 @@ It is also possible to use Elevation on its own to lift one part of the content 
 
 Related topics:
 
-- [Button](button.md)
-- [Card](cards.md)
-- [Forms](forms.md)
+- [Button](../components/button.md)
+- [Card](../components/cards.md)
+- [Forms](../patterns/form.md)
   <div class="divider--half"></div>
 
 Our community is active and always welcoming to new ideas.

--- a/en/style/material-icons.md
+++ b/en/style/material-icons.md
@@ -60,7 +60,7 @@ With the preset collection of icons, you can design beautiful apps and pick the 
 
 Related topics:
 
-- The [Icon](icon.md) Component
+- The [Icon](../components/icon.md) Component
   <div class="divider--half"></div>
 
 Our community is active and always welcoming to new ideas.

--- a/en/style/typography.md
+++ b/en/style/typography.md
@@ -84,9 +84,9 @@ The Text property may contain text, binding, or a combination of the two, exam
 
 Related topics:
 
-- [Avatar](avatar.md)
-- [Hyperlink](hyperlink.md)
-- [Text](text.md)
+- [Avatar](../components/avatar.md)
+- [Hyperlink](../components/hyperlink.md)
+- [Text](../components/text.md)
   <div class="divider--half"></div>
 
 Our community is active and always welcoming to new ideas.

--- a/jp/patterns/av.md
+++ b/jp/patterns/av.md
@@ -24,8 +24,8 @@ AV パターンのレイアウトに含まれる Icon Buttons および Linear P
 
 関連トピック:
 
-- [Button](button.md)
-- [Progress](progress.md)
+- [Button](../components/button.md)
+- [Progress](../components/progress.md)
   <div class="divider--half"></div>
 
 コミュニティに参加して新しいアイデアをご提案ください。

--- a/jp/patterns/avatar-badge.md
+++ b/jp/patterns/avatar-badge.md
@@ -36,8 +36,8 @@ Badge はオーバーライドによって Avatar の 4 つ角のいずれかに
 
 関連トピック:
 
-- [Avatar](avatar.md)
-- [Badge](badge.md)
+- [Avatar](../components/avatar.md)
+- [Badge](../components/badge.md)
   <div class="divider--half"></div>
 
 コミュニティに参加して新しいアイデアをご提案ください。

--- a/jp/patterns/card-collection.md
+++ b/jp/patterns/card-collection.md
@@ -25,8 +25,8 @@ Card Collection パターンは Card の様々なタイプおよび (ある場�
 
 関連トピック:
 
-- [Cards](cards.md)
-- [Input](input.md)
+- [Cards](../components/cards.md)
+- [Input](../components/input.md)
   <div class="divider--half"></div>
 
 コミュニティに参加して新しいアイデアをご提案ください。

--- a/jp/patterns/checkbox-group.md
+++ b/jp/patterns/checkbox-group.md
@@ -25,7 +25,7 @@ Checkbox Group パターンは、含まれる Checkbox 要素のスタイル設�
 
 関連トピック:
 
-- [Checkbox](checkbox.md)
+- [Checkbox](../components/checkbox.md)
   <div class="divider--half"></div>
 
 コミュニティに参加して新しいアイデアをご提案ください。

--- a/jp/patterns/details.md
+++ b/jp/patterns/details.md
@@ -28,10 +28,10 @@ Details Pattern はレイアウトに含まれる以下の利用可能な要素�
 
 関連トピック:
 
-- [Badge](badge.md)
-- [Button](button.md)
-- [Tabs](tabs.md)
-- [Text](text.md)
+- [Badge](../components/badge.md)
+- [Button](../components/button.md)
+- [Tabs](../components/tabs.md)
+- [Text](../components/text.md)
   <div class="divider--half"></div>
 
 コミュニティに参加して新しいアイデアをご提案ください。

--- a/jp/patterns/file-upload.md
+++ b/jp/patterns/file-upload.md
@@ -34,8 +34,8 @@ File Upload パターンは、アップロードまたは Document として挿�
 
 関連トピック:
 
-- [Avatar](avatar.md)
-- [Button](button.md)
+- [Avatar](../components/avatar.md)
+- [Button](../components/button.md)
   <div class="divider--half"></div>
 
 コミュニティに参加して新しいアイデアをご提案ください。

--- a/jp/patterns/form.md
+++ b/jp/patterns/form.md
@@ -61,11 +61,11 @@ Inputs オーバーライドで選択可能な新規フォームの 2 種類が�
 
 関連トピック:
 
-- [Button](button.md)
-- [Checkbox](checkbox.md)
-- [Hyperlink](hyperlink.md)
-- [Input](input.md)
-- [Text](text.md)
+- [Button](../components/button.md)
+- [Checkbox](../components/checkbox.md)
+- [Hyperlink](../components/hyperlink.md)
+- [Input](../components/input.md)
+- [Text](../components/text.md)
   <div class="divider--half"></div>
 
 コミュニティに参加して新しいアイデアをご提案ください。

--- a/jp/patterns/full-grid.md
+++ b/jp/patterns/full-grid.md
@@ -25,7 +25,7 @@ _language: ja
 
 関連トピック:
 
-- [Grid](grid.md)
+- [Grid](../components/grid.md)
 
 コミュニティに参加して新しいアイデアをご提案ください。
 

--- a/jp/patterns/image-manipulation.md
+++ b/jp/patterns/image-manipulation.md
@@ -28,8 +28,8 @@ Image Manipulation パターンは 1 ～ 2 Flat Button、FAB Button、または 
 
 関連トピック:
 
-- [Avatar](avatar.md)
-- [Button](button.md)
+- [Avatar](../components/avatar.md)
+- [Button](../components/button.md)
   <div class="divider--half"></div>
 
 コミュニティに参加して新しいアイデアをご提案ください。

--- a/jp/patterns/lists.md
+++ b/jp/patterns/lists.md
@@ -24,8 +24,8 @@ Lists パターンは List Item の様々なタイプおよび (ある場合) Se
 
 関連トピック:
 
-- [Input](input.md)
-- [List](list.md)
+- [Input](../components/input.md)
+- [List](../components/list.md)
   <div class="divider--half"></div>
 
 コミュニティに参加して新しいアイデアをご提案ください。

--- a/jp/patterns/user-profile.md
+++ b/jp/patterns/user-profile.md
@@ -23,9 +23,9 @@ User Profile パターンの編集可能なバリアントもあります。User
 
 関連トピック:
 
-- [Avatar](avatar.md)
-- [Text](text.md)
-- [Input](input.md)
+- [Avatar](../components/avatar.md)
+- [Text](../components/text.md)
+- [Input](../components/input.md)
   <div class="divider--half"></div>
 
 コミュニティに参加して新しいアイデアをご提案ください。

--- a/jp/style/elevation.md
+++ b/jp/style/elevation.md
@@ -34,9 +34,9 @@ _language: ja
 
 関連トピック:
 
-- [Button](button.md)
-- [Card](cards.md)
-- [Forms](forms.md)
+- [Button](../components/button.md)
+- [Card](../components/cards.md)
+- [Forms](../patterns/form.md)
   <div class="divider--half"></div>
 
 コミュニティに参加して新しいアイデアをご提案ください。

--- a/jp/style/material-icons.md
+++ b/jp/style/material-icons.md
@@ -66,7 +66,7 @@ Icon Buttons、List Items、Cards などで全般的な操作を記号として�
 
 関連トピック:
 
-- [Icon](icon.md) コンポーネント
+- [Icon](../components/icon.md) コンポーネント
   <div class="divider--half"></div>
 
 コミュニティに参加して新しいアイデアをご提案ください。

--- a/jp/style/typography.md
+++ b/jp/style/typography.md
@@ -85,9 +85,9 @@ Text プロパティにテキスト、バインディング、または両方を
 
 関連トピック:
 
-- [Avatar](avatar.md)
-- [Hyperlink](hyperlink.md)
-- [Text](text.md)
+- [Avatar](../components/avatar.md)
+- [Hyperlink](../components/hyperlink.md)
+- [Text](../components/text.md)
   <div class="divider--half"></div>
 
 コミュニティに参加して新しいアイデアをご提案ください。


### PR DESCRIPTION
Fixed links in EN and JP.  They need to be relative paths to the topics.  That means, if you're in a patterns topic and you want to link to a components topic, you need to go up one level, into the components folder, and then reference the file.