### PR TITLE
Added Full Grid pattern to TOC

### DIFF
--- a/en/sidebar-toc/toc.yml
+++ b/en/sidebar-toc/toc.yml
@@ -108,6 +108,8 @@
       href: ../patterns/file-upload.md
     - name: Forms
       href: ../patterns/form.md
+    - name: Full Grid
+      href: ../patterns/full-grid.md
     - name: Gallery
       href: ../patterns/gallery.md
     - name: Image Manipulation

--- a/jp/sidebar-toc/toc.yml
+++ b/jp/sidebar-toc/toc.yml
@@ -108,6 +108,8 @@
       href: ../patterns/file-upload.md
     - name: Forms
       href: ../patterns/form.md
+    - name: Full Grid
+      href: ../patterns/full-grid.md
     - name: Gallery
       href: ../patterns/gallery.md
     - name: Image Manipulation


### PR DESCRIPTION
I noticed that the Full Grid was removed when I synced the Japanese TOC with the English one.  I assume it should be added in both?  If not, I can remove it from English.  And if it's not ready to be released in either language, just close the pull request.