### PR TITLE
Fixing build warnings in EN and JP versions.

### DIFF
--- a/en/docfx.json
+++ b/en/docfx.json
@@ -48,6 +48,7 @@
         "postProcessors": ["SetEnvironmentVariables"],
         "noLangKeyword": false,
         "keepFileLink": false,
-        "cleanupCacheHistory": false
+        "cleanupCacheHistory": false,
+        "disableGitFeatures": true
     }
 }

--- a/en/style/material-icons.md
+++ b/en/style/material-icons.md
@@ -11,7 +11,7 @@ Use the Material Icons to symbolize common actions in Icon Buttons, List Items, 
 <img src="../images/icons_demo.png" srcset="../images/icons_demo@2x.png 2x" />
 
 > [!Note]
-> The Components library provides dedicated [Icon](icon.md) symbol for four icon sizes: ExtraLarge, Large, Medium and Small. Use these when creating intricate layouts for articles, custom Cards and List Items etc. rather than the Styling library directly.
+> The Components library provides dedicated [Icon](../components/icon.md) symbol for four icon sizes: ExtraLarge, Large, Medium and Small. Use these when creating intricate layouts for articles, custom Cards and List Items etc. rather than the Styling library directly.
 
 ### Available Material Icons
 

--- a/en/style/typography.md
+++ b/en/style/typography.md
@@ -11,7 +11,7 @@ Use Typography to set up your theme's typeface and available sizes. Although we 
 <img src="../images/typography_default.png" srcset="../images/typography_default@2x.png 2x" />
 
 > [!Note]
-> The Components library provides dedicated [Text](text.md) symbols for Titles and Paragraphs. Use these when creating intricate layouts for articles, blog posts etc. rather than the Styling library directly. Typography is meant to help you define a consistent theme and style for all the texts in your designs.
+> The Components library provides dedicated [Text](../components/text.md) symbols for Titles and Paragraphs. Use these when creating intricate layouts for articles, blog posts etc. rather than the Styling library directly. Typography is meant to help you define a consistent theme and style for all the texts in your designs.
 
 ### Typography colors
 
@@ -21,7 +21,7 @@ Typography comes in multiple preset colors such as: `grays.900`, `grays.600`, `w
 
 ### Component specific typography
 
-Components, such as [Avatar](avatar.md), [Hyperlink](hyperlink.md), and [Text](text.md), use component-specific Typography to accommodate the specifics of the styling used by the respective component e.g. the Avatar needs a larger variety of colors, while the Hyperlink comes with an underlined text.
+Components, such as [Avatar](../components/avatar.md), [Hyperlink](../components/hyperlink.md), and [Text](../components/text.md), use component-specific Typography to accommodate the specifics of the styling used by the respective component e.g. the Avatar needs a larger variety of colors, while the Hyperlink comes with an underlined text.
 
 <img src="../images/typography_specific.png" srcset="../images/typography_specific@2x.png 2x" />
 

--- a/jp/components/icon.md
+++ b/jp/components/icon.md
@@ -57,7 +57,7 @@ Icon の色を指定した場合、Icon HTML 要素は div でラップされま
 関連トピック:
 
 - [Bottom Navigation](bottom-nav.md)
-- [Card](card.md)
+- [Card](cards.md)
 - [Navbar](navbar.md)
 - [Navigation Drawer](nav-drawer.md)
 - [Tabs](tabs.md)

--- a/jp/docfx.json
+++ b/jp/docfx.json
@@ -45,6 +45,7 @@
         "postProcessors": ["SetEnvironmentVariables"],
         "noLangKeyword": false,
         "keepFileLink": false,
-        "cleanupCacheHistory": false
+        "cleanupCacheHistory": false,
+        "disableGitFeatures": true
     }
 }

--- a/jp/style/material-icons.md
+++ b/jp/style/material-icons.md
@@ -12,7 +12,7 @@ Icon Buttons、List Items、Cards などで全般的な操作を記号として�
 <img src="../images/icons_demo.png" srcset="../images/icons_demo@2x.png 2x" />
 
 > [!Note]
-> コンポーネント ライブラリは 4 つのアイコン サイズ (ExtraLarge、Large、Medium、および Small) で [Icon](icon.md) シンボルを提供します。記事、カスタム Card および List Item の高度なレイアウトを作成で直接スタイリング ライブラリを使用する代わりにこのアイコンを使用します。
+> コンポーネント ライブラリは 4 つのアイコン サイズ (ExtraLarge、Large、Medium、および Small) で [Icon](../components/icon.md) シンボルを提供します。記事、カスタム Card および List Item の高度なレイアウトを作成で直接スタイリング ライブラリを使用する代わりにこのアイコンを使用します。
 
 ### マテリアル アイコン
 

--- a/jp/style/typography.md
+++ b/jp/style/typography.md
@@ -12,7 +12,7 @@ _language: ja
 <img src="../images/typography_default.png" srcset="../images/typography_default@2x.png 2x" />
 
 > [!Note]
-> コンポーネント ライブラリは Title および Paragraph の [Text](text.md) シンボルを提供します。記事、ブログ投稿の高度なレイアウトの作成で直接にスタイリング ライブラリを使用する代わりにこのアイコンを使用します。タイポグラフィは、デザインのすべてのテキストで一貫性のあるテーマおよびスタイルを定義します。
+> コンポーネント ライブラリは Title および Paragraph の [Text](../components/text.md) シンボルを提供します。記事、ブログ投稿の高度なレイアウトの作成で直接にスタイリング ライブラリを使用する代わりにこのアイコンを使用します。タイポグラフィは、デザインのすべてのテキストで一貫性のあるテーマおよびスタイルを定義します。
 
 ### タイポグラフィ色
 
@@ -22,7 +22,7 @@ _language: ja
 
 ### コンポーネント固有のタイポグラフィ
 
-[Avatar](avatar.md)、[Hyperlink](hyperlink.md)、[Text](text.md) などのコンポーネントは仕様のコンポーネント固有のタイポグラフィを使用します。たとえば、Avatar は複数の色を使用し、Hyperlink は下線テキストを使用します。
+[Avatar](../components/avatar.md)、[Hyperlink](../components/hyperlink.md)、[Text](../components/text.md) などのコンポーネントは仕様のコンポーネント固有のタイポグラフィを使用します。たとえば、Avatar は複数の色を使用し、Hyperlink は下線テキストを使用します。
 
 <img src="../images/typography_specific.png" srcset="../images/typography_specific@2x.png 2x" />
 


### PR DESCRIPTION
For the EN version:
 - links are fixed except for **getting-started-old.md**
 - The link to **images/details_content.png** in **patterns/details.md** is broken because such file doesn't exist:
![missingpic](https://user-images.githubusercontent.com/25771040/47222790-52bb7a80-d3c0-11e8-830b-d5618d781618.PNG)

For the JP version:
- links are fixed except for **usability-study-results-overview.md**, the problem is that this link:
![brokenlink](https://user-images.githubusercontent.com/25771040/47222968-bfcf1000-d3c0-11e8-9468-b0eef1833070.PNG) doesn't work.

 
