### PR TITLE
[35315] Carousel: Remove Sketch and Adobe XD references (en)

### DIFF
--- a/en/components/carousel.md
+++ b/en/components/carousel.md
@@ -1,7 +1,7 @@
 ---
 title: Carousel - Design System Component
 _description: The Carousel Component Symbol allows sequential browsing through a collection of images. 
-_keywords: Design Systems, Design Systems UX, UI kit, Figma, Figma to Angular, Export code from Figma, Figma to HTML, Figma UI kits, Sketch, Ignite UI for Angular, Sketch to Angular, Angular, Angular Design System, Export code from Sketch, Design Kits for Angular, Sketch HTML, Sketch to HTML, Sketch UI kits, Adobe XD, Adobe XD to Angular, Export code from Adobe XD, Adobe XD to HTML, Adobe XD UI kits
+_keywords: Design Systems, Design Systems UX, UI kit, Figma, Figma to Angular, Export code from Figma, Figma to HTML, Figma UI kits, Ignite UI for Angular, Angular, Angular Design System, Design Kits for Angular, Figma HTML
 ---
 
 # Carousel
@@ -14,7 +14,7 @@ Use the Carousel Component to let the user navigate through a collection of imag
 
 ## Indicators and Slides
 
-The Carousel lets you define up to 5 slides, where for each one there is a matching indicator dot, allowing the user to navigate to that respective slide. In **Figma**, you can adjust the amount of indicators by hiding the layers, and the auto layout will adjust the layout. In **Sketch**, indicator states are achieved with `Symbol Overrides` and you can adjust their amount by setting the unnecessary indicators to ~No Symbol, the smart layout rules applied allow the layout to adjust accordingly. In **Adobe XD** we are using the `Component States` paradigm to let you easily switch between them and you can adjust the amount simply by deleting the layers of the unnecessary indicators, the applied stack will take care to adjust the layout accordingly.
+The Carousel lets you define up to 5 slides, where for each one there is a matching indicator dot, allowing the user to navigate to that respective slide. In **Figma**, you can adjust the amount of indicators by hiding the layers, and the auto layout will adjust the layout. 
 
 <img class="responsive-img" src="../images/carousel_indicators&slides.png" srcset="../images/carousel_indicators&slides@2x.png 2x" />
 

--- a/en/components/carousel.md
+++ b/en/components/carousel.md
@@ -14,7 +14,7 @@ Use the Carousel Component to let the user navigate through a collection of imag
 
 ## Indicators and Slides
 
-The Carousel lets you define up to 5 slides, where for each one there is a matching indicator dot, allowing the user to navigate to that respective slide. In **Figma**, you can adjust the amount of indicators by hiding the layers, and the auto layout will adjust the layout. 
+The Carousel allows you to define up to five slides, each paired with a corresponding indicator dot for seamless navigation. In **Figma**, you can easily adjust the number of indicators by hiding layers, with the layout automatically adapting to reflect the changes.
 
 <img class="responsive-img" src="../images/carousel_indicators&slides.png" srcset="../images/carousel_indicators&slides@2x.png 2x" />
 


### PR DESCRIPTION
1. Remove Sketch and Adobe XD references in carousel component