### PR TITLE
[35433] Tooltip: Remove Sketch and Adobe XD references

### DIFF
--- a/en/components/tooltip.md
+++ b/en/components/tooltip.md
@@ -1,7 +1,7 @@
 ---
 title: Tooltip - Design System Component
 _description: The Tooltip Component Symbol displays additional informative text upon user interaction with a component.
-_keywords: Design Systems, Design Systems UX, UI kit, Figma, Figma to Angular, Export code from Figma, Figma to HTML, Figma UI kits, Sketch, Ignite UI for Angular, Sketch to Angular, Angular, Angular Design System, Export code from Sketch, Design Kits for Angular, Sketch HTML, Sketch to HTML, Sketch UI kits
+_keywords: Design Systems, Design Systems UX, UI kit, Figma, Figma to Angular, Export code from Figma, Figma to HTML, Figma HTML, Figma UI kits, Ignite UI for Angular, Angular, Angular Design System, Design Kits for Angular
 ---
 
 # Tooltip

--- a/en/components/tooltip.md
+++ b/en/components/tooltip.md
@@ -1,6 +1,6 @@
 ---
 title: Tooltip - Design System Component
-_description: The Tooltip Component Symbol displays additional informative text upon user interaction with a component.
+_description: The Tooltip Component displays additional informative text upon user interaction with a component.
 _keywords: Design Systems, Design Systems UX, UI kit, Figma, Figma to Angular, Export code from Figma, Figma to HTML, Figma HTML, Figma UI kits, Ignite UI for Angular, Angular, Angular Design System, Design Kits for Angular
 ---
 


### PR DESCRIPTION
1. Removed Sketch and Adobe XD references in tooltip component